### PR TITLE
Adjust staff access flow and simplify master onboarding

### DIFF
--- a/field_service/bots/admin_bot/handlers_staff.py
+++ b/field_service/bots/admin_bot/handlers_staff.py
@@ -273,17 +273,21 @@ async def staff_toggle_active(cq: CallbackQuery, state: FSMContext) -> None:
     await cq.answer("Updated")
 
 
+# ВАЖНО: этот хэндлер должен ловить ТОЛЬКО выбор роли, а не шаг выбора города.
 @router.callback_query(
-    F.data.startswith("adm:staff:new:"),
+    F.data.in_(
+        {
+            "adm:staff:new:GLOBAL_ADMIN",
+            "adm:staff:new:CITY_ADMIN",
+            "adm:staff:new:LOGIST",
+        }
+    ),
     StaffRoleFilter({StaffRole.GLOBAL_ADMIN}),
 )
 async def access_code_new_start(cq: CallbackQuery, state: FSMContext, staff: StaffUser) -> None:
     role_token = cq.data.split(":")[3]
-    try:
-        role = StaffRole(role_token)
-    except ValueError:
-        await cq.answer("Unknown role", show_alert=True)
-        return
+    # безопасно после ужесточения фильтра
+    role = StaffRole(role_token)
     await state.clear()
     if role is StaffRole.GLOBAL_ADMIN:
         service = _staff_service(cq.message.bot)

--- a/field_service/bots/master_bot/handlers/onboarding.py
+++ b/field_service/bots/master_bot/handlers/onboarding.py
@@ -2,7 +2,6 @@
 
 import math
 from typing import Sequence
-import re
 
 from aiogram import F, Router
 from aiogram.exceptions import TelegramBadRequest
@@ -54,46 +53,14 @@ async def onboarding_start(
         return
     await state.clear()
     await state.update_data(step_msg_ids=[], last_step_msg_id=None)
-    await state.set_state(OnboardingStates.access_code)
+    await state.set_state(OnboardingStates.pdn)
     await push_step_message(
         callback,
         state,
-        "Введите код доступа (6 символов: латиница и цифры).",
+        MASTER_PDN_CONSENT,
+        reply_markup=pdn_keyboard(),
     )
     await callback.answer()
-
-
-ACCESS_CODE_RE = re.compile(r"^[A-Z0-9]{6}$")
-
-
-@router.message(OnboardingStates.access_code)
-async def onboarding_access_code(
-    message: Message,
-    state: FSMContext,
-    session: AsyncSession,
-) -> None:
-    raw_code = (message.text or "").strip().upper()
-    if not ACCESS_CODE_RE.fullmatch(raw_code):
-        await message.answer("Код доступа должен состоять из 6 символов A-Z или 0-9.")
-        return
-
-    record = await _fetch_staff_access_code(session, raw_code)
-    source = "staff" if record else None
-
-    if record is None:
-        try:
-            legacy = await onboarding_service.validate_access_code(session, raw_code)
-        except onboarding_service.AccessCodeError:
-            await message.answer(
-                "Код доступа не найден. Проверьте правильность и попробуйте снова."
-            )
-            return
-        record = legacy
-        source = "master"
-
-    await state.update_data(access_code={"id": record.id, "source": source})
-    await state.set_state(OnboardingStates.pdn)
-    await push_step_message(message, state, MASTER_PDN_CONSENT, pdn_keyboard())
 
 
 @router.callback_query(OnboardingStates.pdn, F.data == "m:onboarding:pdn_accept")
@@ -738,21 +705,4 @@ def _format_payout_summary(method_value: str | None, payload: dict | None) -> st
         return f"Банк счёт ••••{last4}" if last4 else "Банковские реквизиты"
     return method.value
 
-
-async def _fetch_staff_access_code(
-    session: AsyncSession, normalized_code: str
-) -> m.staff_access_codes | None:
-    now = now_utc()
-    stmt = (
-        select(m.staff_access_codes)
-        .where(func.upper(m.staff_access_codes.code) == normalized_code)
-        .where(m.staff_access_codes.is_revoked.is_(False))
-        .where(m.staff_access_codes.used_at.is_(None))
-        .where(
-            (m.staff_access_codes.expires_at.is_(None))
-            | (m.staff_access_codes.expires_at >= now)
-        )
-        .limit(1)
-    )
-    return (await session.execute(stmt)).scalar_one_or_none()
 

--- a/field_service/bots/master_bot/states.py
+++ b/field_service/bots/master_bot/states.py
@@ -4,7 +4,6 @@ from aiogram.fsm.state import State, StatesGroup
 
 
 class OnboardingStates(StatesGroup):
-    access_code = State()
     pdn = State()
     last_name = State()
     first_name = State()


### PR DESCRIPTION
## Summary
- restrict the staff invite handler to explicit role selection callbacks and simplify role parsing
- start master onboarding directly from the PDN consent step and drop the obsolete access code lookup logic
- remove the unused state that tracked the onboarding access code

## Testing
- pytest tests/test_staff_access.py::test_access_code_issue_and_use *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68d93ab5785c8324a340263404a92266