### PR TITLE
Introduce safe Telegram helpers and refresh master flows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: no-mojibake
+        name: Check for mojibake sequences
+        entry: python tools/check_no_mojibake.py
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/field_service/bots/admin_bot/handlers.py
+++ b/field_service/bots/admin_bot/handlers.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import html
 import json
@@ -12,7 +12,11 @@ from typing import Any, Optional, Sequence
 from zoneinfo import ZoneInfo
 
 from aiogram import F, Router, Bot
-from field_service.bots.common import FSMTimeoutConfig, FSMTimeoutMiddleware
+from field_service.bots.common import (
+    FSMTimeoutConfig,
+    FSMTimeoutMiddleware,
+    safe_send_message,
+)
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command, CommandStart, StateFilter
 from aiogram.fsm.context import FSMContext
@@ -26,10 +30,7 @@ async def _fsm_timeout_notice(state: FSMContext) -> None:
     if chat_id is None:
         return
     try:
-        await state.bot.send_message(
-            chat_id,
-            "Session timed out. Use /start to return to the menu.",
-        )
+        await safe_send_message(state.bot, chat_id, FSM_TIMEOUT_MESSAGE)
     except Exception:
         pass
 
@@ -75,81 +76,10 @@ from .states import (
     StaffAccessFSM,
 )
 from field_service.bots.admin_bot.services_db import AccessCodeError
-
-# Auto-fix mojibake in outgoing texts (display-only)
-def _ru_best_fix(text: str) -> str:
-    if not isinstance(text, str) or not text:
-        return text
-    suspect_chars = "ÐÑРС�â€™�“”•—‹›"
-    suspect = any(ch in text for ch in suspect_chars) or "\u0014" in text
-    if not suspect:
-        return text
-    def score(s: str) -> tuple[int, int]:
-        vowels = set("аеёиоуыэюяАЕЁИОУЫЭЮЯ")
-        return (sum(1 for ch in s if ch in vowels), sum(1 for ch in s if ch in suspect_chars))
-    base = text
-    base_score = score(base)
-    candidates = []
-    for enc, dec in (("cp1251","utf-8"),("utf-8","cp1251"),("latin1","utf-8"),("utf-8","latin1")):
-        try:
-            candidates.append(text.encode(enc, errors="ignore").decode(dec, errors="ignore"))
-        except Exception:
-            pass
-    best = base
-    best_tuple = (base_score[0], -base_score[1])
-    for cand in candidates:
-        sc = score(cand)
-        tup = (sc[0], -sc[1])
-        if tup > best_tuple:
-            best, best_tuple = cand, tup
-    return best
-
-# Monkey-patch common send/edit helpers to fix text at the edge
-try:
-    from aiogram.types import (
-        Message as _AioMessage,
-        CallbackQuery as _AioCallbackQuery,
-        InlineKeyboardButton as _AioInlineButton,
-    )
-    from aiogram import Bot as _AioBot
-
-    _orig_msg_answer = _AioMessage.answer
-    _orig_msg_edit_text = _AioMessage.edit_text
-    _orig_cq_answer = _AioCallbackQuery.answer
-    _orig_bot_send_message = _AioBot.send_message
-
-    async def _fx_msg_answer(self, text: str, *args, **kwargs):
-        return await _orig_msg_answer(self, _ru_best_fix(text), *args, **kwargs)
-
-    async def _fx_msg_edit_text(self, text: str, *args, **kwargs):
-        return await _orig_msg_edit_text(self, _ru_best_fix(text), *args, **kwargs)
-
-    async def _fx_cq_answer(self, text: str | None = None, *args, **kwargs):
-        if isinstance(text, str):
-            text = _ru_best_fix(text)
-        return await _orig_cq_answer(self, text, *args, **kwargs)
-
-    async def _fx_bot_send_message(self, chat_id, text: str, *args, **kwargs):
-        return await _orig_bot_send_message(self, chat_id, _ru_best_fix(text), *args, **kwargs)
-
-    _orig_inline_button_init = _AioInlineButton.__init__
-
-    def _fx_inline_button_init(self, **data):
-        text = data.get("text")
-        if isinstance(text, str):
-            data["text"] = _ru_best_fix(text)
-        _orig_inline_button_init(self, **data)
-
-    _AioMessage.answer = _fx_msg_answer  # type: ignore[assignment]
-    _AioMessage.edit_text = _fx_msg_edit_text  # type: ignore[assignment]
-    _AioCallbackQuery.answer = _fx_cq_answer  # type: ignore[assignment]
-    _AioBot.send_message = _fx_bot_send_message  # type: ignore[assignment]
-    _AioInlineButton.__init__ = _fx_inline_button_init  # type: ignore[assignment]
-except Exception:
-    pass
+from .texts import FSM_TIMEOUT_MESSAGE
 
 def _maybe_fix_mojibake(s: Any) -> Any:
-    return _ru_best_fix(s) if isinstance(s, str) else s
+    return s
 
 # ---------- Читаемые русские константы (override) ----------
 # Эти присваивания гарантируют, что пользователь увидит нормальные строки,

--- a/field_service/bots/admin_bot/texts.py
+++ b/field_service/bots/admin_bot/texts.py
@@ -13,6 +13,9 @@ from .dto import (
     OrderListItem,
 )
 
+FSM_TIMEOUT_MESSAGE = "Сессия истекла. Нажмите /start"
+
+
 COMMISSION_STATUS_LABELS = {
     'WAIT_PAY': 'Ожидает оплаты',
     'REPORTED': 'Проверяется',

--- a/field_service/bots/common/__init__.py
+++ b/field_service/bots/common/__init__.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
 from .fsm_timeout import FSMTimeoutConfig, FSMTimeoutMiddleware
+from .telegram_safe import safe_answer_callback, safe_edit_or_send, safe_send_message
 
-__all__ = ["FSMTimeoutConfig", "FSMTimeoutMiddleware"]
+__all__ = [
+    "FSMTimeoutConfig",
+    "FSMTimeoutMiddleware",
+    "safe_answer_callback",
+    "safe_edit_or_send",
+    "safe_send_message",
+]

--- a/field_service/bots/common/polling.py
+++ b/field_service/bots/common/polling.py
@@ -16,7 +16,10 @@ async def poll_with_single_instance_guard(
     """Run dispatcher polling handling 409 conflicts gracefully."""
 
     try:
-        await dispatcher.start_polling(bot)
+        await dispatcher.start_polling(
+            bot,
+            allowed_updates=dispatcher.resolve_used_update_types(),
+        )
     except ClientResponseError as error:
         if error.status == 409:
             await send_log(bot, "409 Conflict: another instance running → exit", chat_id=logs_chat_id)

--- a/field_service/bots/common/telegram_safe.py
+++ b/field_service/bots/common/telegram_safe.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramNetworkError, TelegramRetryAfter
+from aiogram.types import CallbackQuery, InlineKeyboardMarkup, Message
+
+
+_LOGGER = logging.getLogger(__name__)
+_T = TypeVar("_T")
+
+
+class _SendQueue:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    async def call(self, factory: Callable[[], Awaitable[_T]]) -> _T:
+        delay = 1.0
+        while True:
+            async with self._lock:
+                try:
+                    return await factory()
+                except TelegramRetryAfter as exc:  # pragma: no cover - network timing
+                    wait_time = max(float(exc.retry_after), delay)
+                except TelegramBadRequest as exc:  # pragma: no cover - network timing
+                    message = (exc.message or "").lower()
+                    if "too many requests" not in message:
+                        raise
+                    wait_time = delay
+                except TelegramNetworkError:  # pragma: no cover - flaky network
+                    wait_time = delay
+            await asyncio.sleep(wait_time)
+            delay = min(delay * 2, 30.0)
+
+
+_SEND_QUEUES: dict[int, _SendQueue] = {}
+
+
+def _queue_for(bot: Bot) -> _SendQueue:
+    key = id(bot)
+    queue = _SEND_QUEUES.get(key)
+    if queue is None:
+        queue = _SendQueue()
+        _SEND_QUEUES[key] = queue
+    return queue
+
+
+async def _queue_call(bot: Bot, factory: Callable[[], Awaitable[_T]]) -> _T:
+    queue = _queue_for(bot)
+    return await queue.call(factory)
+
+
+async def safe_edit_or_send(
+    event: Message | CallbackQuery,
+    text: str,
+    reply_markup: InlineKeyboardMarkup | None = None,
+    **kwargs: Any,
+) -> Message | None:
+    """Edit the source message when possible or send a replacement."""
+
+    if isinstance(event, CallbackQuery):
+        message = event.message
+        if message is not None:
+            try:
+                return await _queue_call(
+                    message.bot,
+                    lambda: message.edit_text(text, reply_markup=reply_markup, **kwargs),
+                )
+            except TelegramBadRequest as exc:
+                message_text = (exc.message or "").lower()
+                if "message is not modified" in message_text:
+                    return message
+                if "message to edit not found" not in message_text and "message can't be edited" not in message_text:
+                    _LOGGER.debug("safe_edit_or_send edit failed: %s", exc, exc_info=True)
+                target_chat = message.chat.id
+                return await _queue_call(
+                    message.bot,
+                    lambda: message.bot.send_message(
+                        target_chat,
+                        text,
+                        reply_markup=reply_markup,
+                        **kwargs,
+                    ),
+                )
+        if event.from_user is not None:
+            return await _queue_call(
+                event.bot,
+                lambda: event.bot.send_message(
+                    event.from_user.id,
+                    text,
+                    reply_markup=reply_markup,
+                    **kwargs,
+                ),
+            )
+        return None
+
+    if isinstance(event, Message):
+        return await _queue_call(
+            event.bot,
+            lambda: event.answer(text, reply_markup=reply_markup, **kwargs),
+        )
+
+    raise TypeError(f"Unsupported event type: {type(event)!r}")
+
+
+async def safe_answer_callback(
+    callback: CallbackQuery,
+    text: str | None = None,
+    *,
+    show_alert: bool = False,
+    fallback_message: str = "Кнопка устарела, нажмите /start",
+) -> None:
+    """Answer callback queries, handling stale or repeated callbacks."""
+
+    if callback is None:
+        return
+    try:
+        await _queue_call(callback.bot, lambda: callback.answer(text, show_alert=show_alert))
+    except TelegramBadRequest as exc:
+        message = (exc.message or "").lower()
+        if "query is too old" in message:
+            if callback.from_user is not None:
+                await _queue_call(
+                    callback.bot,
+                    lambda: callback.bot.send_message(callback.from_user.id, fallback_message),
+                )
+            return
+        if "query id not found" in message:
+            return
+        raise
+
+
+async def safe_send_message(bot: Bot, chat_id: int, text: str, **kwargs: Any) -> Message:
+    return await _queue_call(bot, lambda: bot.send_message(chat_id, text, **kwargs))

--- a/field_service/bots/master_bot/handlers/__init__.py
+++ b/field_service/bots/master_bot/handlers/__init__.py
@@ -1,12 +1,13 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from datetime import timedelta
 
 from aiogram import Router
 from aiogram.fsm.context import FSMContext
 
-from field_service.bots.common import FSMTimeoutConfig, FSMTimeoutMiddleware
+from field_service.bots.common import FSMTimeoutConfig, FSMTimeoutMiddleware, safe_send_message
 
+from ..texts import FSM_TIMEOUT_MESSAGE
 from ..middlewares import DbSessionMiddleware, MasterContextMiddleware
 from .finance import router as finance_router
 from .onboarding import router as onboarding_router
@@ -14,57 +15,6 @@ from .orders import router as orders_router
 from .referral import router as referral_router
 from .shift import router as shift_router
 from .start import router as start_router
-
-
-# --- Auto-fix mojibake in outgoing texts (display-only) ---
-import html as _py_html
-
-def _ru_best_fix(text: str) -> str:
-    if not isinstance(text, str) or not text:
-        return text
-    suspect_chars = "?N��?a?T?""\u0007-<>"
-    if not any(ch in text for ch in suspect_chars) and "\u0014" not in text:
-        return text
-    def score(s: str) -> tuple[int, int]:
-        vowels = set("аеёиоуыэюяАЕЁИОУЫЭЮЯ")
-        return (sum(1 for ch in s if ch in vowels), sum(1 for ch in s if ch in suspect_chars))
-    base = text
-    best = base
-    best_tuple = (0, 0)
-    for enc, dec in (("cp1251","utf-8"),("utf-8","cp1251"),("latin1","utf-8"),("utf-8","latin1")):
-        try:
-            cand = text.encode(enc, errors='ignore').decode(dec, errors='ignore')
-        except Exception:
-            continue
-        sc = score(cand)
-        tup = (sc[0], -sc[1])
-        if tup > best_tuple:
-            best, best_tuple = cand, tup
-    return best
-
-try:
-    from aiogram.types import Message as _AioMessage, CallbackQuery as _AioCallbackQuery
-    from aiogram import Bot as _AioBot
-    _orig_msg_answer = _AioMessage.answer
-    _orig_msg_edit_text = _AioMessage.edit_text
-    _orig_cq_answer = _AioCallbackQuery.answer
-    _orig_bot_send_message = _AioBot.send_message
-    async def _fx_msg_answer(self, text: str, *args, **kwargs):
-        return await _orig_msg_answer(self, _ru_best_fix(text), *args, **kwargs)
-    async def _fx_msg_edit_text(self, text: str, *args, **kwargs):
-        return await _orig_msg_edit_text(self, _ru_best_fix(text), *args, **kwargs)
-    async def _fx_cq_answer(self, text: str | None = None, *args, **kwargs):
-        if isinstance(text, str):
-            text = _ru_best_fix(text)
-        return await _orig_cq_answer(self, text, *args, **kwargs)
-    async def _fx_bot_send_message(self, chat_id, text: str, *args, **kwargs):
-        return await _orig_bot_send_message(self, chat_id, _ru_best_fix(text), *args, **kwargs)
-    _AioMessage.answer = _fx_msg_answer  # type: ignore
-    _AioMessage.edit_text = _fx_msg_edit_text  # type: ignore
-    _AioCallbackQuery.answer = _fx_cq_answer  # type: ignore
-    _AioBot.send_message = _fx_bot_send_message  # type: ignore
-except Exception:
-    pass
 
 router = Router(name="master_bot")
 
@@ -74,12 +24,8 @@ async def _notify_timeout(state: FSMContext) -> None:
     if chat_id is None:
         return
     try:
-        await state.bot.send_message(
-            chat_id,
-            "Session timed out. Send /start to continue.",
-        )
+        await safe_send_message(state.bot, chat_id, FSM_TIMEOUT_MESSAGE)
     except Exception:
-        # Notification is optional; ignore delivery failures (e.g., bot was blocked).
         pass
 
 
@@ -99,8 +45,4 @@ router.include_router(onboarding_router)
 router.include_router(shift_router)
 router.include_router(orders_router)
 router.include_router(referral_router)
-
 router.include_router(finance_router)
-
-
-

--- a/field_service/bots/master_bot/handlers/finance.py
+++ b/field_service/bots/master_bot/handlers/finance.py
@@ -16,28 +16,32 @@ from field_service.db import models as m
 
 from ..finance import format_pay_snapshot
 from ..states import FinanceUploadStates
+from field_service.bots.common import safe_answer_callback, safe_edit_or_send
 from ..utils import inline_keyboard, now_utc
 
 router = Router(name="master_finance")
 
 COMMISSIONS_PAGE_SIZE = 5
 FINANCE_MODES: dict[str, tuple[str, tuple[m.CommissionStatus, ...]]] = {
-    "aw": (" ", (m.CommissionStatus.WAIT_PAY, m.CommissionStatus.REPORTED)),
-    "pd": ("", (m.CommissionStatus.APPROVED,)),
-    "ov": ("", (m.CommissionStatus.OVERDUE,)),
+    "aw": (
+        "💳 К оплате",
+        (m.CommissionStatus.WAIT_PAY, m.CommissionStatus.REPORTED),
+    ),
+    "pd": ("✅ Выплачено", (m.CommissionStatus.APPROVED,)),
+    "ov": ("⚠️ Просрочено", (m.CommissionStatus.OVERDUE,)),
 }
 MODE_ORDER = ("aw", "pd", "ov")
 
 STATUS_LABELS: dict[m.CommissionStatus, str] = {
-    m.CommissionStatus.WAIT_PAY: " ",
-    m.CommissionStatus.REPORTED: "  ",
-    m.CommissionStatus.APPROVED: "",
-    m.CommissionStatus.OVERDUE: "",
+    m.CommissionStatus.WAIT_PAY: "Ожидает оплаты",
+    m.CommissionStatus.REPORTED: "Отправлен отчёт",
+    m.CommissionStatus.APPROVED: "Оплата подтверждена",
+    m.CommissionStatus.OVERDUE: "Просрочено",
 }
 
 ORDER_TYPE_LABELS: dict[m.OrderType, str] = {
-    m.OrderType.NORMAL: "",
-    m.OrderType.GUARANTEE: "",
+    m.OrderType.NORMAL: "Обычный заказ",
+    m.OrderType.GUARANTEE: "Гарантийный визит",
 }
 
 
@@ -49,7 +53,7 @@ async def finances_root(
     master: m.masters,
 ) -> None:
     await _render_commission_list(callback, session, master, mode="aw", page=1, state=state)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:fin:(aw|pd|ov):(\d+)$"))
@@ -62,7 +66,7 @@ async def finances_page(
     _, _, mode, page_str = callback.data.split(":")
     page = int(page_str)
     await _render_commission_list(callback, session, master, mode=mode, page=page, state=state)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:fin:cm:(\d+)$"))
@@ -74,7 +78,7 @@ async def finances_card(
 ) -> None:
     commission_id = int(callback.data.split(":")[-1])
     await _render_commission_card(callback, session, master, commission_id, state)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:fin:cm:pt:(\d+)$"))
@@ -86,22 +90,22 @@ async def finances_show_payto(
     commission_id = int(callback.data.split(":")[-1])
     commission = await _get_commission(session, master.id, commission_id)
     if commission is None:
-        await callback.answer("  .", show_alert=True)
+        await safe_answer_callback(callback, "Комиссия не найдена.", show_alert=True)
         return
 
     snapshot_text = format_pay_snapshot(commission.pay_to_snapshot)
     if snapshot_text:
         await callback.message.answer(snapshot_text)
     else:
-        await callback.message.answer(" .")
+        await callback.message.answer("Реквизиты для оплаты пока недоступны.")
 
     qr_id = commission.pay_to_snapshot.get("sbp_qr_file_id") if commission.pay_to_snapshot else None
     if qr_id:
         try:
             await callback.message.answer_photo(qr_id)
         except TelegramBadRequest:
-            await callback.message.answer("   QR-.")
-    await callback.answer()
+            await callback.message.answer("Не удалось отправить QR-код.")
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:fin:cm:chk:(\d+)$"))
@@ -114,13 +118,13 @@ async def finances_request_check(
     commission_id = int(callback.data.split(":")[-1])
     commission = await _get_commission(session, master.id, commission_id)
     if commission is None:
-        await callback.answer("  .", show_alert=True)
+        await safe_answer_callback(callback, "Комиссия не найдена.", show_alert=True)
         return
 
     await state.update_data(fin_upload={"commission_id": commission_id})
     await state.set_state(FinanceUploadStates.check)
-    await callback.message.answer("    (  PDF).")
-    await callback.answer()
+    await callback.message.answer("Загрузите чек (фото или PDF одним файлом).")
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:fin:cm:ip:(\d+)$"))
@@ -133,14 +137,14 @@ async def finances_mark_paid(
     commission_id = int(callback.data.split(":")[-1])
     commission = await _get_commission(session, master.id, commission_id)
     if commission is None:
-        await callback.answer("  .", show_alert=True)
+        await safe_answer_callback(callback, "Комиссия не найдена.", show_alert=True)
         return
 
     commission.paid_reported_at = now_utc()
     if commission.status == m.CommissionStatus.WAIT_PAY:
         commission.status = m.CommissionStatus.REPORTED
     await session.commit()
-    await callback.answer(" .  .", show_alert=True)
+    await safe_answer_callback(callback, "Спасибо! Отметили платёж.", show_alert=True)
     await _render_commission_card(callback, session, master, commission_id, state)
 
 
@@ -158,13 +162,15 @@ async def finances_upload_check(
     upload = data.get("fin_upload") or {}
     commission_id = upload.get("commission_id")
     if commission_id is None:
-        await message.answer("-   .     .")
+        await message.answer(
+            "Не удалось определить комиссию. Вернитесь к списку финансов и попробуйте снова."
+        )
         await state.clear()
         return
 
     commission = await _get_commission(session, master.id, int(commission_id))
     if commission is None:
-        await message.answer("  .")
+        await message.answer("Комиссия не найдена.")
         await state.clear()
         return
 
@@ -184,13 +190,13 @@ async def finances_upload_check(
 
     await state.set_state(None)
     await state.update_data(fin_upload=None)
-    await message.answer(" .")
+    await message.answer("Чек загружен. Спасибо!")
     await _render_commission_card(message, session, master, commission.id, state)
 
 
 @router.message(FinanceUploadStates.check)
 async def finances_upload_invalid(message: Message) -> None:
-    await message.answer("    PDF-.")
+    await message.answer("Пожалуйста, отправьте фото или PDF-файл чека.")
 
 
 async def _render_commission_list(
@@ -212,31 +218,33 @@ async def _render_commission_list(
     start = (page - 1) * COMMISSIONS_PAGE_SIZE
     current = rows[start : start + COMMISSIONS_PAGE_SIZE]
 
-    lines: list[str] = [f"{title}"]
+    lines: list[str] = [f"<b>{title}</b>"]
     buttons: list[list[InlineKeyboardButton]] = []
 
     mode_buttons: list[InlineKeyboardButton] = []
     for code in MODE_ORDER:
         caption, _ = FINANCE_MODES[code]
-        label = f"* {caption}" if code == mode else caption
+        label = f"• {caption}" if code == mode else caption
         mode_buttons.append(InlineKeyboardButton(text=label, callback_data=f"m:fin:{code}:1"))
     buttons.append(mode_buttons)
 
     if not current:
-        lines.append("No commissions in this section.")
+        lines.append("Комиссий в этом разделе пока нет.")
     else:
         for commission in current:
             lines.append(_commission_summary_line(commission))
-            lines.append(f"Status: {STATUS_LABELS.get(commission.status, commission.status.value)}")
+            lines.append(
+                f"Статус: {STATUS_LABELS.get(commission.status, commission.status.value)}"
+            )
             if commission.deadline_at:
                 lines.append(
-                    f": {commission.deadline_at.strftime('%d.%m %H:%M')}"
+                    f"Оплатить до: {commission.deadline_at.strftime('%d.%m %H:%M')}"
                 )
             lines.append("")
             buttons.append(
                 [
                     InlineKeyboardButton(
-                        text=f" #{commission.id}",
+                        text=f"Открыть #{commission.id}",
                         callback_data=f"m:fin:cm:{commission.id}",
                     )
                 ]
@@ -244,15 +252,17 @@ async def _render_commission_list(
 
         nav: list[InlineKeyboardButton] = []
         if page > 1:
-            nav.append(InlineKeyboardButton(text="<", callback_data=f"m:fin:{mode}:{page - 1}"))
-        nav.append(InlineKeyboardButton(text=f"{page}/{pages}", callback_data="noop"))
+            nav.append(InlineKeyboardButton(text="◀️", callback_data=f"m:fin:{mode}:{page - 1}"))
+        nav.append(
+            InlineKeyboardButton(text=f"{page}/{pages}", callback_data=f"m:fin:{mode}:{page}")
+        )
         if page < pages:
-            nav.append(InlineKeyboardButton(text=">", callback_data=f"m:fin:{mode}:{page + 1}"))
+            nav.append(InlineKeyboardButton(text="▶️", callback_data=f"m:fin:{mode}:{page + 1}"))
         if nav:
             buttons.append(nav)
 
-    buttons.append([InlineKeyboardButton(text="", callback_data="m:menu")])
-    await _respond(event, "\n".join([line for line in lines if line]), inline_keyboard(buttons))
+    buttons.append([InlineKeyboardButton(text="⬅️ В главное меню", callback_data="m:menu")])
+    await safe_edit_or_send(event, "\n".join([line for line in lines if line]), inline_keyboard(buttons))
 
 
 async def _render_commission_card(
@@ -264,62 +274,68 @@ async def _render_commission_card(
 ) -> None:
     row = await _load_commission_detail(session, master.id, commission_id)
     if row is None:
-        if isinstance(event, Message):
-            await event.answer("  .")
-        elif isinstance(event, CallbackQuery) and event.message:
-            await event.message.answer("  .")
+        await safe_edit_or_send(
+            event,
+            "Комиссия не найдена.",
+            inline_keyboard([[InlineKeyboardButton(text="⬅️ В главное меню", callback_data="m:menu")]]),
+        )
         return
 
     commission = row.commission
     order = row.order
     status_label = STATUS_LABELS.get(commission.status, commission.status.value)
 
-    lines = [f" #{commission.id}", status_label]
+    lines = [
+        f"<b>💳 Комиссия #{commission.id}</b>",
+        f"Статус: {status_label}",
+        f"Сумма к оплате: {Decimal(commission.amount):.2f} ₽",
+    ]
     if order:
         order_label = ORDER_TYPE_LABELS.get(order.order_type, order.order_type.value)
-        lines.append(f" {order.id} ({order_label})")
+        lines.append(f"Заказ #{order.id} ({order_label})")
         if order.total_sum is not None:
-            lines.append(f" : {Decimal(order.total_sum):.2f} ")
-    lines.append(f": {Decimal(commission.amount):.2f} ")
+            lines.append(f"Сумма заказа: {Decimal(order.total_sum):.2f} ₽")
 
     rate = commission.rate or commission.percent
     if rate is not None:
         rate_decimal = Decimal(str(rate))
         rate_percent = rate_decimal * 100 if rate_decimal <= 1 else rate_decimal
-        lines.append(f": {rate_percent:.2f}%")
+        lines.append(f"Ставка: {rate_percent:.2f}%")
 
     if commission.deadline_at:
-        lines.append(f": {commission.deadline_at.strftime('%d.%m %H:%M')}")
+        lines.append(f"Оплатить до: {commission.deadline_at.strftime('%d.%m %H:%M')}")
     if commission.paid_reported_at:
-        lines.append(f"  : {commission.paid_reported_at.strftime('%d.%m %H:%M')}")
+        lines.append(f"Отправлено: {commission.paid_reported_at.strftime('%d.%m %H:%M')}")
     if commission.paid_approved_at:
-        lines.append(f": {commission.paid_approved_at.strftime('%d.%m %H:%M')}")
+        lines.append(f"Подтверждено: {commission.paid_approved_at.strftime('%d.%m %H:%M')}")
     if commission.paid_amount is not None:
-        lines.append(f" : {Decimal(commission.paid_amount):.2f} ")
-    lines.append(f" : {'' if commission.has_checks else ''}")
+        lines.append(f"Оплачено: {Decimal(commission.paid_amount):.2f} ₽")
+    lines.append(
+        "Чеки загружены." if commission.has_checks else "Чеки ещё не загружены."
+    )
 
     buttons: list[list[InlineKeyboardButton]] = []
     buttons.append([
-        InlineKeyboardButton(text="", callback_data=f"m:fin:cm:pt:{commission.id}")
+        InlineKeyboardButton(text="📄 Реквизиты", callback_data=f"m:fin:cm:pt:{commission.id}")
     ])
     buttons.append([
-        InlineKeyboardButton(text=" ", callback_data=f"m:fin:cm:chk:{commission.id}")
+        InlineKeyboardButton(text="📎 Прикрепить чек", callback_data=f"m:fin:cm:chk:{commission.id}")
     ])
     if commission.status in {m.CommissionStatus.WAIT_PAY, m.CommissionStatus.REPORTED}:
         buttons.append([
-            InlineKeyboardButton(text=" ", callback_data=f"m:fin:cm:ip:{commission.id}")
+            InlineKeyboardButton(text="✅ Я оплатил", callback_data=f"m:fin:cm:ip:{commission.id}")
         ])
 
     ctx = await state.get_data()
     fin_ctx = ctx.get("fin_ctx", {"mode": "aw", "page": 1})
     buttons.append([
         InlineKeyboardButton(
-            text="",
+            text="⬅️ Назад",
             callback_data=f"m:fin:{fin_ctx.get('mode', 'aw')}:{fin_ctx.get('page', 1)}",
         )
     ])
 
-    await _respond(event, "\n".join([line for line in lines if line]), inline_keyboard(buttons))
+    await safe_edit_or_send(event, "\n".join([line for line in lines if line]), inline_keyboard(buttons))
 
 
 async def _load_commissions(
@@ -383,25 +399,7 @@ async def _get_commission(
 
 def _commission_summary_line(commission: m.commissions) -> str:
     amount = Decimal(commission.amount)
-    summary = f" {commission.id}  {amount:.2f} "
+    summary = f"#{commission.id} • {amount:.2f} ₽"
     if commission.deadline_at:
-        summary += f"   {commission.deadline_at.strftime('%d.%m %H:%M')}"
+        summary += f" • оплатить до {commission.deadline_at.strftime('%d.%m %H:%M')}"
     return summary
-
-
-async def _respond(
-    event: Message | CallbackQuery,
-    text: str,
-    markup: InlineKeyboardMarkup | None,
-) -> None:
-    if isinstance(event, CallbackQuery) and event.message:
-        try:
-            await event.message.edit_text(text, reply_markup=markup)
-            return
-        except TelegramBadRequest:
-            await event.message.answer(text, reply_markup=markup)
-            return
-    if isinstance(event, Message):
-        await event.answer(text, reply_markup=markup)
-    elif isinstance(event, CallbackQuery) and event.message:
-        await event.message.answer(text, reply_markup=markup)

--- a/field_service/bots/master_bot/handlers/orders.py
+++ b/field_service/bots/master_bot/handlers/orders.py
@@ -7,18 +7,52 @@ from typing import Optional
 from types import SimpleNamespace
 
 from aiogram import F, Router
-from aiogram.exceptions import TelegramBadRequest
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, ContentType, InlineKeyboardButton, InlineKeyboardMarkup, Message
 from sqlalchemy import and_, func, insert, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from field_service.bots.common import safe_answer_callback, safe_edit_or_send
 from field_service.db import models as m
 from field_service.config import settings
 from field_service.services import time_service
 from field_service.services.commission_service import CommissionService
 
 from ..states import CloseOrderStates
+from ..texts import (
+    ACTIVE_STATUS_ACTIONS,
+    ActiveOrderCard,
+    CLOSE_ACT_PROMPT,
+    CLOSE_AMOUNT_ERROR,
+    CLOSE_AMOUNT_PROMPT,
+    CLOSE_DOCUMENT_ERROR,
+    CLOSE_DOCUMENT_RECEIVED,
+    CLOSE_PAYMENT_TEMPLATE,
+    CLOSE_SUCCESS_TEMPLATE,
+    BACK_TO_MENU,
+    BACK_TO_OFFERS,
+    OFFERS_EMPTY,
+    OFFERS_HEADER_TEMPLATE,
+    OFFERS_REFRESH_BUTTON,
+    NO_ACTIVE_ORDERS,
+    ORDER_STATUS_TITLES,
+    ALERT_ACCEPT_SUCCESS,
+    ALERT_ACCOUNT_BLOCKED,
+    ALERT_ALREADY_TAKEN,
+    ALERT_CLOSE_NOT_ALLOWED,
+    ALERT_CLOSE_NOT_FOUND,
+    ALERT_CLOSE_STATUS,
+    ALERT_DECLINE_SUCCESS,
+    ALERT_EN_ROUTE_FAIL,
+    ALERT_EN_ROUTE_SUCCESS,
+    ALERT_LIMIT_REACHED,
+    ALERT_ORDER_NOT_FOUND,
+    ALERT_WORKING_FAIL,
+    ALERT_WORKING_SUCCESS,
+    offer_card,
+    offer_line,
+    OFFER_NOT_FOUND,
+)
 from ..utils import escape_html, inline_keyboard, normalize_money, now_utc
 
 router = Router(name="master_orders")
@@ -30,7 +64,6 @@ ACTIVE_STATUSES: tuple[m.OrderStatus, ...] = (
     m.OrderStatus.WORKING,
     m.OrderStatus.PAYMENT,
 )
-
 
 
 def _timeslot_text(
@@ -49,7 +82,7 @@ async def offers_root(
     master: m.masters,
 ) -> None:
     await _render_offers(callback, session, master, page=1)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:new:(\d+)$"))
@@ -60,7 +93,7 @@ async def offers_page(
 ) -> None:
     page = int(callback.data.rsplit(":", 1)[-1])
     await _render_offers(callback, session, master, page=page)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:new:card:(\d+)(?::(\d+))?$"))
@@ -73,7 +106,7 @@ async def offers_card(
     order_id = int(parts[2])
     page = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else 1
     await _render_offer_card(callback, session, master, order_id, page)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:new:acc:(\d+)(?::(\d+))?$"))
@@ -87,13 +120,38 @@ async def offer_accept(
     page = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else 1
 
     if master.is_blocked:
-        await callback.answer(" :  .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_ACCOUNT_BLOCKED, show_alert=True)
         return
 
     limit = await _get_active_limit(session, master)
     active_orders = await _count_active_orders(session, master.id)
     if limit and active_orders >= limit:
-        await callback.answer("   .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_LIMIT_REACHED, show_alert=True)
+        return
+
+    order_snapshot = await session.execute(
+        select(m.orders.status, m.orders.assigned_master_id, m.orders.version)
+        .where(m.orders.id == order_id)
+        .limit(1)
+    )
+    row = order_snapshot.first()
+    if row is None:
+        await safe_answer_callback(callback, ALERT_ORDER_NOT_FOUND, show_alert=True)
+        await _render_offers(callback, session, master, page=page)
+        return
+
+    current_status: m.OrderStatus = row.status
+    assigned_master_id = row.assigned_master_id
+    current_version = row.version or 1
+    allowed_statuses = {
+        m.OrderStatus.SEARCHING,
+        m.OrderStatus.GUARANTEE,
+        m.OrderStatus.CREATED,
+    }
+
+    if assigned_master_id is not None or current_status not in allowed_statuses:
+        await safe_answer_callback(callback, ALERT_ALREADY_TAKEN, show_alert=True)
+        await _render_offers(callback, session, master, page=page)
         return
 
     updated = await session.execute(
@@ -102,20 +160,21 @@ async def offer_accept(
             and_(
                 m.orders.id == order_id,
                 m.orders.assigned_master_id.is_(None),
-                m.orders.status.in_(
-                    (m.OrderStatus.CREATED, m.OrderStatus.SEARCHING, m.OrderStatus.GUARANTEE)
-                ),
+                m.orders.status == current_status,
+                m.orders.version == current_version,
             )
         )
         .values(
             assigned_master_id=master.id,
             status=m.OrderStatus.ASSIGNED,
             updated_at=func.now(),
+            version=current_version + 1,
         )
         .returning(m.orders.id)
     )
     if not updated.first():
-        await callback.answer("    .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_ALREADY_TAKEN, show_alert=True)
+        await _render_offers(callback, session, master, page=page)
         return
 
     await session.execute(
@@ -137,7 +196,7 @@ async def offer_accept(
     await session.execute(
         insert(m.order_status_history).values(
             order_id=order_id,
-            from_status=m.OrderStatus.SEARCHING,
+            from_status=current_status,
             to_status=m.OrderStatus.ASSIGNED,
             changed_by_master_id=master.id,
             reason="accepted_by_master",
@@ -145,7 +204,7 @@ async def offer_accept(
     )
     await session.commit()
 
-    await callback.answer(" .")
+    await safe_answer_callback(callback, ALERT_ACCEPT_SUCCESS, show_alert=True)
     await _render_offers(callback, session, master, page=page)
 
 
@@ -166,7 +225,7 @@ async def offer_decline(
     )
     await session.commit()
 
-    await callback.answer(" .")
+    await safe_answer_callback(callback, ALERT_DECLINE_SUCCESS)
     await _render_offers(callback, session, master, page=page)
 
 
@@ -177,7 +236,7 @@ async def active_order_entry(
     master: m.masters,
 ) -> None:
     await _render_active_order(callback, session, master, order_id=None)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:act:card:(\d+)$"))
@@ -188,7 +247,7 @@ async def active_order_card(
 ) -> None:
     order_id = int(callback.data.split(":")[-1])
     await _render_active_order(callback, session, master, order_id=order_id)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data.regexp(r"^m:act:enr:(\d+)$"))
@@ -207,9 +266,9 @@ async def active_set_enroute(
         reason="master_en_route",
     )
     if not changed:
-        await callback.answer("   .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_EN_ROUTE_FAIL, show_alert=True)
         return
-    await callback.answer(" .")
+    await safe_answer_callback(callback, ALERT_EN_ROUTE_SUCCESS)
     await _render_active_order(callback, session, master, order_id=order_id)
 
 
@@ -229,9 +288,9 @@ async def active_set_working(
         reason="master_working",
     )
     if not changed:
-        await callback.answer("   .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_WORKING_FAIL, show_alert=True)
         return
-    await callback.answer(" .")
+    await safe_answer_callback(callback, ALERT_WORKING_SUCCESS)
     await _render_active_order(callback, session, master, order_id=order_id)
 
 
@@ -245,32 +304,32 @@ async def active_close_start(
     order_id = int(callback.data.split(":")[-1])
     order = await session.get(m.orders, order_id)
     if order is None or order.assigned_master_id != master.id:
-        await callback.answer("  .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_ORDER_NOT_FOUND, show_alert=True)
         return
     if order.status != m.OrderStatus.WORKING:
-        await callback.answer("      .", show_alert=True)
+        await safe_answer_callback(callback, ALERT_CLOSE_NOT_ALLOWED, show_alert=True)
         return
 
     await state.update_data(close_order_id=order_id)
     if order.order_type == m.OrderType.GUARANTEE:
         await state.update_data(close_order_amount=str(Decimal("0")))
         await state.set_state(CloseOrderStates.act)
-        await callback.message.answer("  (  PDF).")
+        await callback.message.answer(CLOSE_ACT_PROMPT)
     else:
         await state.set_state(CloseOrderStates.amount)
-        await callback.message.answer("  ,  3500  4999.99.")
-    await callback.answer()
+        await callback.message.answer(CLOSE_AMOUNT_PROMPT)
+    await safe_answer_callback(callback)
 
 
 @router.message(CloseOrderStates.amount)
 async def active_close_amount(message: Message, state: FSMContext) -> None:
     amount = normalize_money(message.text or "")
     if amount is None:
-        await message.answer("  . : 3500  4999.99.")
+        await message.answer(CLOSE_AMOUNT_ERROR)
         return
     await state.update_data(close_order_amount=str(amount))
     await state.set_state(CloseOrderStates.act)
-    await message.answer("  (  PDF).")
+    await message.answer(CLOSE_ACT_PROMPT)
 
 
 @router.message(
@@ -289,11 +348,11 @@ async def active_close_act(
 
     order = await session.get(m.orders, order_id)
     if order is None or order.assigned_master_id != master.id:
-        await message.answer("     .")
+        await message.answer(ALERT_CLOSE_NOT_FOUND)
         await state.clear()
         return
     if order.status != m.OrderStatus.WORKING:
-        await message.answer("     .")
+        await message.answer(ALERT_CLOSE_STATUS)
         await state.clear()
         return
 
@@ -345,15 +404,16 @@ async def active_close_act(
     await state.clear()
 
     if is_guarantee:
-        await message.answer(f" #{order_id}   .")
+        await message.answer(CLOSE_SUCCESS_TEMPLATE.format(order_id=order_id))
     else:
-        await message.answer(f" #{order_id} . : {amount:.2f} ")
+        payment_text = CLOSE_PAYMENT_TEMPLATE.format(order_id=order_id, amount=amount)
+        await message.answer(f"{payment_text}\n{CLOSE_DOCUMENT_RECEIVED}")
     await _render_active_order(message, session, master, order_id=order_id)
 
 
 @router.message(CloseOrderStates.act)
 async def active_close_act_invalid(message: Message) -> None:
-    await message.answer(",       PDF.")
+    await message.answer(CLOSE_DOCUMENT_ERROR)
 
 
 async def _render_offers(
@@ -365,8 +425,10 @@ async def _render_offers(
 ) -> None:
     offers = await _load_offers(session, master.id)
     if not offers:
-        keyboard = inline_keyboard([[InlineKeyboardButton(text="", callback_data="m:new")]])
-        await _respond(event, "  .", keyboard)
+        keyboard = inline_keyboard(
+            [[InlineKeyboardButton(text=OFFERS_REFRESH_BUTTON, callback_data="m:new")]]
+        )
+        await safe_edit_or_send(event, OFFERS_EMPTY, keyboard)
         return
 
     total = len(offers)
@@ -375,34 +437,48 @@ async def _render_offers(
     start = (page - 1) * OFFERS_PAGE_SIZE
     chunk = offers[start : start + OFFERS_PAGE_SIZE]
 
-    lines = ["<b> </b>"]
+    lines = [OFFERS_HEADER_TEMPLATE.format(page=page, pages=pages, total=total), ""]
     keyboard_rows: list[list[InlineKeyboardButton]] = []
     for item in chunk:
         order_id = item.order_id
-        city = escape_html(item.city or "N/A")
-        district = f" / {escape_html(item.district)}" if item.district else ""
-        category = item.category.value if isinstance(item.category, m.OrderCategory) else str(item.category or "N/A")
-        lines.append(f"#{order_id} - {city}{district} - {category}")
+        category_value = (
+            item.category.value
+            if isinstance(item.category, m.OrderCategory)
+            else str(item.category or "—")
+        )
+        lines.append(
+            offer_line(
+                order_id,
+                item.city or "—",
+                item.district,
+                category_value,
+                item.timeslot_text,
+            )
+        )
         keyboard_rows.append(
             [
                 InlineKeyboardButton(
-                    text=f"#{order_id} - {category}",
+                    text=f"Открыть #{order_id}",
                     callback_data=f"m:new:card:{order_id}:{page}",
                 )
             ]
         )
 
-    nav: list[InlineKeyboardButton] = []
-    if page > 1:
-        nav.append(InlineKeyboardButton(text="<", callback_data=f"m:new:{page - 1}"))
-    nav.append(InlineKeyboardButton(text=f"{page}/{pages}", callback_data="m:new"))
-    if page < pages:
-        nav.append(InlineKeyboardButton(text=">", callback_data=f"m:new:{page + 1}"))
-    if nav:
-        keyboard_rows.append(nav)
+    if pages > 1:
+        nav_row: list[InlineKeyboardButton] = []
+        if page > 1:
+            nav_row.append(
+                InlineKeyboardButton(text="◀️", callback_data=f"m:new:{page - 1}")
+            )
+        if page < pages:
+            nav_row.append(
+                InlineKeyboardButton(text="▶️", callback_data=f"m:new:{page + 1}")
+            )
+        if nav_row:
+            keyboard_rows.append(nav_row)
 
     keyboard = inline_keyboard(keyboard_rows)
-    await _respond(event, "\n".join(lines), keyboard)
+    await safe_edit_or_send(event, "\n".join(lines), keyboard)
 
 
 async def _render_offer_card(
@@ -414,38 +490,53 @@ async def _render_offer_card(
 ) -> None:
     row = await _load_offer_detail(session, master.id, order_id)
     if row is None:
-        await _respond(event, "????? ??????????.", None)
+        await safe_edit_or_send(
+            event,
+            OFFER_NOT_FOUND,
+            inline_keyboard(
+                [[InlineKeyboardButton(text=BACK_TO_OFFERS, callback_data="m:new")]]
+            ),
+        )
         return
 
     order = row.order
-    city = escape_html(row.city or "N/A")
-    district = escape_html(row.district) if row.district else None
-    street = escape_html(row.street) if row.street else None
-
-    lines = [f"<b>????? #{order.id}</b>", f"?????: {city}"]
-    if district:
-        lines.append(f"?????: {district}")
-    if street or order.house:
-        parts = [street or "", escape_html(order.house or "")]
-        lines.append(f"?????: {' '.join(p for p in parts if p).strip() or 'N/A'}")
-    slot_text = _timeslot_text(order.timeslot_start_utc, order.timeslot_end_utc, getattr(row, 'city_tz', None))
-    if slot_text:
-        lines.append(f"????: {escape_html(slot_text)}")
-    category = order.category.value if isinstance(order.category, m.OrderCategory) else order.category
-    lines.append(f"?????????: {category or 'N/A'}")
-    if order.description:
-        lines.extend(["", escape_html(order.description)])
+    slot_text = _timeslot_text(
+        order.timeslot_start_utc,
+        order.timeslot_end_utc,
+        getattr(row, "city_tz", None),
+    )
+    category = (
+        order.category.value
+        if isinstance(order.category, m.OrderCategory)
+        else str(order.category or "—")
+    )
+    card_text = offer_card(
+        order_id=order.id,
+        city=row.city or "—",
+        district=row.district,
+        street=row.street,
+        house=order.house,
+        timeslot=slot_text,
+        category=str(category),
+        description=order.description or "",
+    )
 
     keyboard = inline_keyboard(
         [
             [
-                InlineKeyboardButton(text="?????", callback_data=f"m:new:acc:{order.id}:{page}"),
-                InlineKeyboardButton(text="??????????", callback_data=f"m:new:dec:{order.id}:{page}"),
+                InlineKeyboardButton(
+                    text="✅ Взять",
+                    callback_data=f"m:new:acc:{order.id}:{page}",
+                ),
+                InlineKeyboardButton(
+                    text="✖️ Отказаться",
+                    callback_data=f"m:new:dec:{order.id}:{page}",
+                ),
             ],
-            [InlineKeyboardButton(text="?????", callback_data=f"m:new:{page}")],
+            [InlineKeyboardButton(text=BACK_TO_OFFERS, callback_data="m:new")],
         ]
     )
-    await _respond(event, "\n".join(lines), keyboard)
+    await safe_edit_or_send(event, card_text, keyboard)
 
 
 async def _render_active_order(
@@ -456,47 +547,56 @@ async def _render_active_order(
 ) -> None:
     row = await _load_active_order(session, master.id, order_id)
     if row is None:
-        await _respond(event, "? ??? ??? ???????? ???????.", None)
+        await safe_edit_or_send(
+            event,
+            NO_ACTIVE_ORDERS,
+            inline_keyboard(
+                [[InlineKeyboardButton(text=BACK_TO_MENU, callback_data="m:menu")]]
+            ),
+        )
         return
 
     order = row.order
-    text_lines = [f"<b>????? #{order.id}</b>", f"??????: {order.status.value}"]
-    text_lines.append(f"?????: {escape_html(row.city or 'N/A')}")
-    if row.district:
-        text_lines.append(f"?????: {escape_html(row.district)}")
-    if row.street or order.house:
-        parts = [escape_html(row.street or ''), escape_html(order.house or '')]
-        text_lines.append(f"?????: {' '.join(p for p in parts if p).strip() or 'N/A'}")
-    slot_text = _timeslot_text(order.timeslot_start_utc, order.timeslot_end_utc, getattr(row, 'city_tz', None))
-    if slot_text:
-        text_lines.append(f"????: {escape_html(slot_text)}")
+    slot_text = _timeslot_text(
+        order.timeslot_start_utc,
+        order.timeslot_end_utc,
+        getattr(row, "city_tz", None),
+    )
+    card = ActiveOrderCard(
+        order_id=order.id,
+        city=row.city or "—",
+        district=row.district,
+        street=row.street,
+        house=order.house,
+        timeslot=slot_text,
+        status=order.status,
+        category=order.category.value if isinstance(order.category, m.OrderCategory) else str(order.category or ""),
+    )
+    text_lines = card.lines()
 
-    if order.status in {m.OrderStatus.ASSIGNED, m.OrderStatus.EN_ROUTE, m.OrderStatus.WORKING, m.OrderStatus.PAYMENT}:
-        text_lines.append(f"??????: {escape_html(order.client_name or 'N/A')}")
-        text_lines.append(f"???????: {escape_html(order.client_phone or 'N/A')}")
+    if order.status in ACTIVE_STATUSES or order.status == m.OrderStatus.PAYMENT:
+        text_lines.append(
+            f"👤 Клиент: {escape_html(order.client_name or '—')}"
+        )
+        text_lines.append(
+            f"📞 Телефон: {escape_html(order.client_phone or '—')}"
+        )
 
     if order.description:
         text_lines.extend(["", escape_html(order.description)])
 
     keyboard_rows: list[list[InlineKeyboardButton]] = []
-    if order.status == m.OrderStatus.ASSIGNED:
-        keyboard_rows.append([
-            InlineKeyboardButton(text="? ????", callback_data=f"m:act:enr:{order.id}"),
-        ])
-    if order.status == m.OrderStatus.EN_ROUTE:
-        keyboard_rows.append([
-            InlineKeyboardButton(text="???????", callback_data=f"m:act:wrk:{order.id}"),
-        ])
-    if order.status == m.OrderStatus.WORKING:
-        keyboard_rows.append([
-            InlineKeyboardButton(text="???????", callback_data=f"m:act:cls:{order.id}"),
-        ])
-    keyboard_rows.append([
-        InlineKeyboardButton(text="?????", callback_data="m:menu"),
-    ])
+    action = ACTIVE_STATUS_ACTIONS.get(order.status)
+    if action:
+        title, prefix = action
+        keyboard_rows.append(
+            [InlineKeyboardButton(text=title, callback_data=f"{prefix}:{order.id}")]
+        )
+
+    keyboard_rows.append([InlineKeyboardButton(text=BACK_TO_MENU, callback_data="m:menu")])
     keyboard = inline_keyboard(keyboard_rows)
 
-    await _respond(event, "\n".join(text_lines), keyboard)
+    await safe_edit_or_send(event, "\n".join(text_lines), keyboard)
 
 
 async def _update_order_status(
@@ -655,20 +755,3 @@ async def _count_active_orders(session: AsyncSession, master_id: int) -> int:
     )
     return int((await session.execute(stmt)).scalar_one())
 
-
-async def _respond(
-    event: Message | CallbackQuery,
-    text: str,
-    keyboard: InlineKeyboardMarkup | None,
-) -> None:
-    if isinstance(event, CallbackQuery) and event.message:
-        try:
-            await event.message.edit_text(text, reply_markup=keyboard)
-            return
-        except TelegramBadRequest:
-            await event.message.answer(text, reply_markup=keyboard)
-            return
-    if isinstance(event, Message):
-        await event.answer(text, reply_markup=keyboard)
-    elif isinstance(event, CallbackQuery) and event.message:
-        await event.message.answer(text, reply_markup=keyboard)

--- a/field_service/bots/master_bot/handlers/referral.py
+++ b/field_service/bots/master_bot/handlers/referral.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from decimal import Decimal
 
 from aiogram import F, Router
-from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from field_service.bots.common import safe_answer_callback, safe_edit_or_send
 from field_service.db import models as m
 from field_service.services import settings_service
 
@@ -16,22 +16,22 @@ from ..utils import inline_keyboard
 router = Router(name='master_referral')
 
 REFERRAL_STATUS_LABELS = {
-    m.ReferralRewardStatus.ACCRUED.value: '',
-    m.ReferralRewardStatus.PAID.value: '',
-    m.ReferralRewardStatus.CANCELED.value: '',
+    m.ReferralRewardStatus.ACCRUED.value: "Начислено",
+    m.ReferralRewardStatus.PAID.value: "Выплачено",
+    m.ReferralRewardStatus.CANCELED.value: "Отменено",
 }
 
 
 @router.callback_query(F.data == 'm:rf')
 async def referrals_root(callback: CallbackQuery, session: AsyncSession, master: m.masters) -> None:
     await _render_referrals(callback, session, master)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 @router.callback_query(F.data == 'm:kb')
 async def knowledge_base(callback: CallbackQuery, session: AsyncSession, master: m.masters) -> None:
     await _render_support(callback, session)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 async def _render_referrals(
@@ -88,41 +88,41 @@ async def _render_referrals(
         bucket['amount'] = Decimal(total or 0)
 
     total_amount = level_stats[1]['amount'] + level_stats[2]['amount']
-    lines: list[str] = [" "]
+    lines: list[str] = ["<b>🎁 Реферальная программа</b>"]
     if referral_code:
-        lines.append(f" : {referral_code}")
+        lines.append(f"Ваш код: <code>{referral_code}</code>")
     else:
-        lines.append("    .")
-    lines.append(": L1  10%, L2  5%")
-    lines.append('')
+        lines.append("Код появится после активации аккаунта.")
+    lines.append("Приглашайте мастеров: уровень 1 — 10%, уровень 2 — 5% от комиссии.")
+    lines.append("")
     for level in (1, 2):
         bucket = level_stats[level]
         lines.append(
-            f" {level}: {bucket['count']} , {bucket['amount']:.2f} "
+            f"Уровень {level}: {bucket['count']} приглашений • {bucket['amount']:.2f} ₽"
         )
-    lines.append('')
-    lines.append(f" : {total_amount:.2f} ")
+    lines.append("")
+    lines.append(f"Всего начислено: {total_amount:.2f} ₽")
 
     if latest:
-        lines.append('')
-        lines.append(" :")
+        lines.append("")
+        lines.append("Последние начисления:")
         for row in latest:
             level, amount, created_at, status, commission_id, order_id = row
             amount_dec = Decimal(amount or 0)
             status_key = getattr(status, 'value', status)
             status_label = REFERRAL_STATUS_LABELS.get(status_key, status_key)
-            order_hint = f" {commission_id}"
+            order_hint = f"комиссия #{commission_id}"
             if order_id is not None:
-                order_hint += f",  {order_id}"
+                order_hint += f", заказ #{order_id}"
             lines.append(
-                f"{created_at:%d.%m %H:%M} - L{int(level)} - {amount_dec:.2f}  - {status_label} ({order_hint})"
+                f"{created_at:%d.%m %H:%M} • L{int(level)} • {amount_dec:.2f} ₽ • {status_label} ({order_hint})"
             )
     else:
-        lines.append('')
-        lines.append("   .")
+        lines.append("")
+        lines.append("Начислений пока не было.")
 
-    markup = inline_keyboard([[InlineKeyboardButton(text='', callback_data='m:menu')]])
-    await _respond(event, "\n".join(lines), markup)
+    markup = inline_keyboard([[InlineKeyboardButton(text='⬅️ В главное меню', callback_data='m:menu')]])
+    await safe_edit_or_send(event, "\n".join(lines), markup)
 
 
 async def _render_support(event: Message | CallbackQuery, session: AsyncSession) -> None:
@@ -130,31 +130,13 @@ async def _render_support(event: Message | CallbackQuery, session: AsyncSession)
     contact = (raw_values.get("support_contact", (None, None))[0] or '').strip()
     faq_url = (raw_values.get("support_faq_url", (None, None))[0] or '').strip()
 
-    lines = [""]
-    lines.append('')
-    lines.append(f": {contact or ' '}")
+    lines = ["<b>📚 База знаний</b>"]
+    lines.append(f"Поддержка: {contact or '—'}")
     if faq_url and faq_url != '-':
         lines.append(f"FAQ: {faq_url}")
     else:
-        lines.append("FAQ:  ")
+        lines.append("FAQ: ссылка пока недоступна")
 
-    markup = inline_keyboard([[InlineKeyboardButton(text='', callback_data='m:menu')]])
-    await _respond(event, "\n".join(lines), markup)
+    markup = inline_keyboard([[InlineKeyboardButton(text='⬅️ В главное меню', callback_data='m:menu')]])
+    await safe_edit_or_send(event, "\n".join(lines), markup)
 
-
-async def _respond(
-    event: Message | CallbackQuery,
-    text: str,
-    markup: InlineKeyboardMarkup,
-) -> None:
-    if isinstance(event, CallbackQuery) and event.message:
-        try:
-            await event.message.edit_text(text, reply_markup=markup)
-            return
-        except TelegramBadRequest:
-            await event.message.answer(text, reply_markup=markup)
-            return
-    if isinstance(event, Message):
-        await event.answer(text, reply_markup=markup)
-    elif isinstance(event, CallbackQuery) and event.message:
-        await event.message.answer(text, reply_markup=markup)

--- a/field_service/bots/master_bot/handlers/shift.py
+++ b/field_service/bots/master_bot/handlers/shift.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from datetime import timedelta
 
@@ -6,8 +6,10 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from field_service.bots.common import safe_answer_callback
 from field_service.db import models as m
 
+from ..texts import SHIFT_MESSAGES
 from ..utils import now_utc
 from .start import _render_start
 
@@ -16,19 +18,23 @@ router = Router(name="master_shift")
 BREAK_DURATION = timedelta(hours=2)
 
 
+async def _answer(callback: CallbackQuery, message: str, *, alert: bool = True) -> None:
+    await safe_answer_callback(callback, message, show_alert=alert)
+
+
 @router.callback_query(F.data == "m:sh:on")
 async def shift_on(callback: CallbackQuery, session: AsyncSession, master: m.masters) -> None:
     if master.is_blocked:
-        await callback.answer("Смена недоступна: аккаунт заблокирован.", show_alert=True)
+        await _answer(callback, SHIFT_MESSAGES["blocked"])
         return
     if getattr(master, "moderation_status", m.ModerationStatus.PENDING) != m.ModerationStatus.APPROVED:
-        await callback.answer("Профиль на модерации. Дождитесь одобрения.", show_alert=True)
+        await _answer(callback, SHIFT_MESSAGES["pending"])
         return
     master.shift_status = m.ShiftStatus.SHIFT_ON
     master.is_on_shift = True
     master.break_until = None
     await session.commit()
-    await callback.answer("Смена начата.", show_alert=True)
+    await _answer(callback, SHIFT_MESSAGES["started"])
     if callback.message:
         await _render_start(callback.message, master)
 
@@ -39,7 +45,7 @@ async def shift_off(callback: CallbackQuery, session: AsyncSession, master: m.ma
     master.is_on_shift = False
     master.break_until = None
     await session.commit()
-    await callback.answer("Смена завершена.", show_alert=True)
+    await _answer(callback, SHIFT_MESSAGES["finished"])
     if callback.message:
         await _render_start(callback.message, master)
 
@@ -47,13 +53,13 @@ async def shift_off(callback: CallbackQuery, session: AsyncSession, master: m.ma
 @router.callback_query(F.data == "m:sh:brk")
 async def shift_break_start(callback: CallbackQuery, session: AsyncSession, master: m.masters) -> None:
     if master.shift_status != m.ShiftStatus.SHIFT_ON:
-        await callback.answer("Смена не активна.", show_alert=True)
+        await _answer(callback, SHIFT_MESSAGES["inactive"])
         return
     master.shift_status = m.ShiftStatus.BREAK
     master.is_on_shift = False
     master.break_until = now_utc() + BREAK_DURATION
     await session.commit()
-    await callback.answer("Перерыв 2 часа начат.", show_alert=True)
+    await _answer(callback, SHIFT_MESSAGES["break_started"])
     if callback.message:
         await _render_start(callback.message, master)
 
@@ -61,14 +67,12 @@ async def shift_break_start(callback: CallbackQuery, session: AsyncSession, mast
 @router.callback_query(F.data == "m:sh:brk:ok")
 async def shift_break_end(callback: CallbackQuery, session: AsyncSession, master: m.masters) -> None:
     if master.shift_status != m.ShiftStatus.BREAK:
-        await callback.answer("Сейчас не перерыв.", show_alert=True)
+        await _answer(callback, SHIFT_MESSAGES["not_break"])
         return
     master.shift_status = m.ShiftStatus.SHIFT_ON
     master.is_on_shift = True
     master.break_until = None
     await session.commit()
-    await callback.answer("Вы вернулись на смену.", show_alert=True)
+    await _answer(callback, SHIFT_MESSAGES["break_finished"])
     if callback.message:
         await _render_start(callback.message, master)
-
-

--- a/field_service/bots/master_bot/keyboards.py
+++ b/field_service/bots/master_bot/keyboards.py
@@ -6,12 +6,20 @@ from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from field_service.db import models as m
 
+from .texts import MAIN_MENU_BUTTONS
 from .utils import inline_keyboard
 
 
 def start_onboarding_keyboard() -> InlineKeyboardMarkup:
     return inline_keyboard(
-        [[InlineKeyboardButton(text="Заполнить анкету", callback_data="m:onboarding:start")]]
+        [
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["start_onboarding"],
+                    callback_data="m:onboarding:start",
+                )
+            ]
+        ]
     )
 
 
@@ -93,8 +101,8 @@ def payout_methods_keyboard(methods: Iterable[m.PayoutMethod]) -> InlineKeyboard
 def home_geo_keyboard() -> InlineKeyboardMarkup:
     return inline_keyboard(
         [
-            [InlineKeyboardButton(text="Отправить геопозицию", callback_data="m:onboarding:home_geo_share")],
-            [InlineKeyboardButton(text="Пропустить", callback_data="m:onboarding:home_geo_skip")],
+        [InlineKeyboardButton(text="Отправить геопозицию", callback_data="m:onboarding:home_geo_share")],
+        [InlineKeyboardButton(text="Пропустить", callback_data="m:onboarding:home_geo_skip")],
         ]
     )
 
@@ -104,20 +112,97 @@ def main_menu_keyboard(master: m.masters) -> InlineKeyboardMarkup:
     if getattr(master, "verified", False):
         shift_status = getattr(master, "shift_status", m.ShiftStatus.SHIFT_OFF)
         if shift_status is m.ShiftStatus.SHIFT_OFF:
-            rows.append([InlineKeyboardButton(text="Начать смену", callback_data="m:sh:on")])
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=MAIN_MENU_BUTTONS["shift_on"],
+                        callback_data="m:sh:on",
+                    )
+                ]
+            )
         elif shift_status is m.ShiftStatus.SHIFT_ON:
-            rows.append([InlineKeyboardButton(text="Перерыв 20 мин", callback_data="m:sh:brk")])
-            rows.append([InlineKeyboardButton(text="Завершить смену", callback_data="m:sh:off")])
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=MAIN_MENU_BUTTONS["shift_break"],
+                        callback_data="m:sh:brk",
+                    )
+                ]
+            )
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=MAIN_MENU_BUTTONS["shift_off"],
+                        callback_data="m:sh:off",
+                    )
+                ]
+            )
         elif shift_status is m.ShiftStatus.BREAK:
-            rows.append([InlineKeyboardButton(text="Вернуться на смену", callback_data="m:sh:brk:ok")])
-            rows.append([InlineKeyboardButton(text="Завершить смену", callback_data="m:sh:off")])
-        rows.append([InlineKeyboardButton(text="Новые заказы", callback_data="m:new")])
-        rows.append([InlineKeyboardButton(text="Мои заказы", callback_data="m:act")])
-        rows.append([InlineKeyboardButton(text="Выплаты", callback_data="m:fin")])
-        rows.append([InlineKeyboardButton(text="Рефералы", callback_data="m:rf")])
-        rows.append([InlineKeyboardButton(text="Помощь", callback_data="m:kb")])
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=MAIN_MENU_BUTTONS["shift_break_end"],
+                        callback_data="m:sh:brk:ok",
+                    )
+                ]
+            )
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=MAIN_MENU_BUTTONS["shift_off"],
+                        callback_data="m:sh:off",
+                    )
+                ]
+            )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["new_orders"],
+                    callback_data="m:new",
+                )
+            ]
+        )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["active_order"],
+                    callback_data="m:act",
+                )
+            ]
+        )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["finance"],
+                    callback_data="m:fin",
+                )
+            ]
+        )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["referral"],
+                    callback_data="m:rf",
+                )
+            ]
+        )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["knowledge"],
+                    callback_data="m:kb",
+                )
+            ]
+        )
     else:
-        rows.append([InlineKeyboardButton(text="Заполнить анкету", callback_data="m:onboarding:start")])
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=MAIN_MENU_BUTTONS["start_onboarding"],
+                    callback_data="m:onboarding:start",
+                )
+            ]
+        )
     return inline_keyboard(rows)
 
 

--- a/field_service/bots/master_bot/texts.py
+++ b/field_service/bots/master_bot/texts.py
@@ -1,35 +1,187 @@
 from __future__ import annotations
 
+import html
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from field_service.db import models as m
+
 MASTER_PDN_CONSENT = (
-    " ,         "
-    "  (, ,  , ),    "
-    "    .    ,   "
-    "   ."
+    "Согласие на обработку персональных данных.",
+    "Я разрешаю Field Service обрабатывать мои ФИО, телефон и сведения о заказах для заключения договора и организации работы.",
+    "Я ознакомлен с тем, что могу отозвать согласие, написав в поддержку сервиса.",
 )
 
 MASTER_PDN_DECLINED = (
-    "          ."
+    "Вы отказались от обработки персональных данных. Мы не сможем продолжить регистрацию.",
 )
 
 START_NOT_APPROVED = (
-    "   .  ,   ."
+    "Добро пожаловать в Field Service! Ваша анкета отправлена на модерацию.",
+    "Мы сообщим, как только проверим данные. Пока вы можете дополнить профиль и ознакомиться с требованиями.",
 )
 
 START_BLOCKED = (
-    "  .       "
-    "   ."
+    "Ваш аккаунт заблокирован.",
+    "Если это ошибка, свяжитесь с поддержкой или администратором сервиса.",
 )
 
 START_APPROVED = (
-    "   .       ."
+    "Рады видеть вас на смене! Вы можете включить смену, брать заявки и управлять финансами.",
 )
 
-ONBOARDING_SUMMARY_HEADER = "     :"
+FSM_TIMEOUT_MESSAGE = "Сессия истекла. Нажмите /start"
 
-ONBOARDING_ALREADY_VERIFIED = (
-    "  .      ."
-)
+MAIN_MENU_BUTTONS = {
+    "shift_on": "🟢 Включить смену",
+    "shift_break": "☕ Перерыв 2 часа",
+    "shift_break_end": "🟢 Включить смену",
+    "shift_off": "🔴 Выключить смену",
+    "new_orders": "🆕 Новые заявки",
+    "active_order": "📦 Активный заказ",
+    "finance": "💳 Финансы",
+    "referral": "🎁 Реферальная программа",
+    "knowledge": "📚 База знаний",
+    "start_onboarding": "Заполнить анкету",
+}
 
-ONBOARDING_SENT = (
-    "   .     ."
-)
+ORDER_STATUS_TITLES: Mapping[m.OrderStatus, str] = {
+    m.OrderStatus.ASSIGNED: "Назначено мастеру",
+    m.OrderStatus.EN_ROUTE: "Мастер в пути",
+    m.OrderStatus.WORKING: "Мастер работает",
+    m.OrderStatus.PAYMENT: "Ожидает подтверждения оплаты",
+    m.OrderStatus.CLOSED: "Заказ закрыт",
+    m.OrderStatus.DEFERRED: "Заказ отложен",
+    m.OrderStatus.GUARANTEE: "Гарантийный визит",
+    m.OrderStatus.CANCELED: "Заказ отменён",
+    m.OrderStatus.CREATED: "Создан",
+    m.OrderStatus.SEARCHING: "Идёт поиск мастера",
+}
+
+SHIFT_MESSAGES = {
+    "started": "Смена начата.",
+    "finished": "Смена завершена.",
+    "break_started": "Перерыв 2 часа начат.",
+    "break_finished": "Вы вернулись на смену.",
+    "inactive": "Смена не активна.",
+    "not_break": "Сейчас не перерыв.",
+    "blocked": "Смена недоступна: аккаунт заблокирован.",
+    "pending": "Профиль на модерации. Дождитесь одобрения.",
+}
+
+OFFERS_EMPTY = "Нет новых предложений"
+OFFERS_REFRESH_BUTTON = "🔄 Обновить"
+OFFERS_HEADER_TEMPLATE = "<b>🆕 Новые заявки</b>\nСтраница {page}/{pages} • всего: {total}"
+
+
+def _escape(value: str | None) -> str:
+    return html.escape(value or "—")
+
+
+def offer_line(order_id: int, city: str, district: str | None, category: str, timeslot: str | None) -> str:
+    district_part = f", {_escape(district)}" if district else ""
+    slot = _escape(timeslot or "сегодня/ASAP")
+    return f"#{order_id} • {_escape(city)}{district_part} • {_escape(category)} • {slot}"
+
+
+def offer_card(
+    *,
+    order_id: int,
+    city: str,
+    district: str | None,
+    street: str | None,
+    house: str | None,
+    timeslot: str | None,
+    category: str,
+    description: str | None,
+) -> str:
+    address_parts: list[str] = [
+        _escape(city),
+    ]
+    if district:
+        address_parts.append(_escape(district))
+    if street:
+        address_parts.append(_escape(street))
+    if house:
+        address_parts.append(_escape(str(house)))
+    address = ", ".join(address_parts)
+    description_text = _escape(description.strip() if description else "—")
+    slot = _escape(timeslot or "—")
+    lines = [
+        f"<b>Заявка #{order_id}</b>",
+        f"📍 Адрес: {address}",
+        f"🗓 Слот: {slot}",
+        f"🛠 Категория: {_escape(category)}",
+        f"💬 Описание: {description_text}",
+    ]
+    return "\n".join(lines)
+
+
+@dataclass(slots=True)
+class ActiveOrderCard:
+    order_id: int
+    city: str
+    district: str | None
+    street: str | None
+    house: str | None
+    timeslot: str | None
+    status: m.OrderStatus
+    category: str | None = None
+
+    def lines(self) -> list[str]:
+        address_parts: list[str] = [_escape(self.city)]
+        if self.district:
+            address_parts.append(_escape(self.district))
+        if self.street:
+            address_parts.append(_escape(self.street))
+        if self.house:
+            address_parts.append(_escape(str(self.house)))
+        address = ", ".join(address_parts)
+        status_title = _escape(ORDER_STATUS_TITLES.get(self.status, self.status.value))
+        slot = _escape(self.timeslot or "—")
+        lines = [
+            f"<b>📦 Активный заказ #{self.order_id}</b>",
+            f"📍 Адрес: {address}",
+            f"🗓 Слот: {slot}",
+            f"🔁 Текущий статус: {status_title}",
+        ]
+        if self.category:
+            lines.insert(3, f"🛠 Категория: {_escape(self.category)}")
+        return lines
+
+
+ACTIVE_STATUS_ACTIONS: Mapping[m.OrderStatus, tuple[str, str]] = {
+    m.OrderStatus.ASSIGNED: ("🚗 В пути", "m:act:enr"),
+    m.OrderStatus.EN_ROUTE: ("🛠 На месте", "m:act:wrk"),
+    m.OrderStatus.WORKING: ("🧾 Закрыть", "m:act:cls"),
+}
+
+CLOSE_AMOUNT_PROMPT = "Введите сумму по заказу (например, 3500 или 4999.99)."
+CLOSE_AMOUNT_ERROR = "Некорректная сумма. Введите целое число или число с двумя знаками после точки."
+CLOSE_ACT_PROMPT = "Отправьте акт (фото или PDF одним файлом)."
+CLOSE_SUCCESS_TEMPLATE = "Заказ #{order_id} закрыт. Спасибо за работу!"
+CLOSE_PAYMENT_TEMPLATE = "Заказ #{order_id} отправлен на оплату. Сумма: {amount:.2f} ₽"
+CLOSE_DOCUMENT_RECEIVED = "Документ получен. Проверим и сообщим о результате."
+CLOSE_DOCUMENT_ERROR = "Нужен один файл: фото или PDF. Попробуйте ещё раз."
+
+OFFER_NOT_FOUND = "Заявка не найдена. Возможно, её уже приняли другим мастером."
+BACK_TO_OFFERS = "⬅️ К списку"
+BACK_TO_MENU = "⬅️ В главное меню"
+NO_ACTIVE_ORDERS = "Сейчас нет активных заказов."
+
+ALERT_ACCOUNT_BLOCKED = "Ваш аккаунт заблокирован. Обратитесь в поддержку."
+ALERT_LIMIT_REACHED = "Достигнут лимит активных заказов. Завершите текущие, чтобы брать новые."
+ALERT_ALREADY_TAKEN = "Упс, заказ уже забрали другим мастером"
+ALERT_ACCEPT_SUCCESS = "Заявка принята. Удачи в работе!"
+ALERT_DECLINE_SUCCESS = "Предложение скрыто."
+ALERT_EN_ROUTE_FAIL = "Не удалось перевести заказ в статус «В пути». Обновите карточку и попробуйте снова."
+ALERT_EN_ROUTE_SUCCESS = "Отметили, что вы в пути."
+ALERT_WORKING_FAIL = "Не удалось отметить начало работы. Обновите карточку и попробуйте снова."
+ALERT_WORKING_SUCCESS = "Отметили, что вы уже на месте."
+ALERT_CLOSE_NOT_FOUND = "Заказ не найден. Начните закрытие заново."
+ALERT_CLOSE_STATUS = "Статус заказа изменился. Попробуйте снова из активного заказа."
+ALERT_CLOSE_NOT_ALLOWED = "Сейчас нельзя закрыть этот заказ. Проверьте статус."
+ALERT_ORDER_NOT_FOUND = "Заказ не найден."
+
+REFERRAL_EMPTY = "Пока нет начислений по реферальной программе."
+FINANCE_EMPTY = "Комиссии не найдены."

--- a/field_service/bots/master_bot/utils.py
+++ b/field_service/bots/master_bot/utils.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import html
 import re

--- a/tools/check_no_mojibake.py
+++ b/tools/check_no_mojibake.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PATTERNS = [
+    re.compile(r"Ð[^\s]"),
+    re.compile(r"Ñ[^\s]"),
+    re.compile(r"\u0014"),
+]
+
+
+def has_mojibake(text: str) -> bool:
+    return any(pattern.search(text) for pattern in PATTERNS)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    bad_files: list[Path] = []
+    for path in repo_root.rglob("*.py"):
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            bad_files.append(path)
+            continue
+        if has_mojibake(contents):
+            bad_files.append(path)
+    if bad_files:
+        for path in bad_files:
+            print(path.relative_to(repo_root))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add reusable Telegram safety helpers with rate-limit aware queueing and integrate them into the master bot handlers
- normalize master bot texts, menus, and shift messaging while refreshing the orders flow layouts and copy
- configure pre-commit with linting plus a mojibake guard script and tighten polling with allowed update types

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68dbac22249883249f58a50cbdae8b30