### PR TITLE
Improve master bot navigation and admin callbacks

### DIFF
--- a/field_service/bots/admin_bot/routers/admin_masters.py
+++ b/field_service/bots/admin_bot/routers/admin_masters.py
@@ -1,6 +1,7 @@
 ﻿from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Iterable, Optional
 
@@ -8,7 +9,7 @@ from aiogram import F, Router
 from aiogram.filters import StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.types import CallbackQuery, InlineKeyboardMarkup, Message
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -46,6 +47,46 @@ GROUP_LABELS = {
 
 logger = logging.getLogger(__name__)
 UTC = timezone.utc
+
+
+@dataclass(slots=True)
+class MasterAction:
+    prefix: str
+    action: str
+    master_id: int
+    group: str | None = None
+    category: str | None = None
+    page: int | None = None
+
+    @property
+    def mode(self) -> str:
+        return "moderation" if self.prefix == "adm:mod" else "masters"
+
+
+def parse_master_action(data: str) -> MasterAction:
+    parts = data.split(":")
+    if len(parts) < 3:
+        raise ValueError("Invalid callback data")
+    prefix = ":".join(parts[:2])
+    action = parts[2]
+    tail = parts[3:]
+    if not tail:
+        raise ValueError("Missing master identifier")
+    try:
+        master_id = int(tail[-1])
+    except ValueError as exc:
+        raise ValueError("Invalid master identifier") from exc
+    group = category = None
+    page: int | None = None
+    if len(tail) >= 4:
+        group = tail[-4]
+        category = tail[-3]
+        page_str = tail[-2]
+        try:
+            page = int(page_str)
+        except ValueError:
+            page = None
+    return MasterAction(prefix, action, master_id, group, category, page)
 
 
 class RejectReasonState(StatesGroup):
@@ -142,7 +183,10 @@ def build_list_kb(
 ) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
     for item in items:
-        kb.button(text=f"Открыть #{item.id}", callback_data=f"{prefix}:card:{item.id}")
+        kb.button(
+            text=f"Открыть #{item.id}",
+            callback_data=f"{prefix}:card:{group}:{category}:{page}:{item.id}",
+        )
     if items:
         kb.adjust(1)
 
@@ -182,8 +226,13 @@ def build_list_kb(
         categories.adjust(min(categories_count, 3))
         kb.attach(categories)
 
-    kb.button(text="⬅️ В меню", callback_data="adm:menu")
-    kb.adjust(1)
+    kb.row(
+        InlineKeyboardButton(
+            text="⬅️ Назад",
+            callback_data="adm:menu",
+        ),
+        InlineKeyboardButton(text="🏠 Меню", callback_data="adm:menu"),
+    )
     return kb.as_markup()
 
 
@@ -192,43 +241,63 @@ def build_card_kb(
     staff: StaffUser,
     *,
     mode: str = "masters",
+    prefix: str = "adm:m",
+    group: str | None = None,
+    category: str | None = None,
+    page: int | None = None,
 ) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
     manage = _can_manage(staff) and not detail.is_deleted
+    group_value = group or ("mod" if mode == "moderation" else "ok")
+    category_value = category or "all"
+    page_value = page or 1
+
+    def _action_callback(action: str) -> str:
+        return f"{prefix}:{action}:{group_value}:{category_value}:{page_value}:{detail.id}"
+
+    if mode == "moderation":
+        if manage and not detail.verified:
+            kb.button(text="✅ Одобрить", callback_data=_action_callback("ok"))
+        if manage:
+            kb.button(text="❌ Отклонить", callback_data=_action_callback("rej"))
+        kb.button(text="📄 Документы", callback_data=_action_callback("docs"))
+        kb.adjust(1)
+        kb.row(
+            InlineKeyboardButton(
+                text="⬅️ Назад",
+                callback_data=f"{prefix}:list:{group_value}:{category_value}:{page_value}",
+            ),
+            InlineKeyboardButton(text="🏠 Меню", callback_data="adm:menu"),
+        )
+        return kb.as_markup()
 
     if manage and not detail.verified:
-        kb.button(text="✅ Одобрить", callback_data=f"adm:m:ok:{detail.id}")
+        kb.button(text="✅ Одобрить", callback_data=_action_callback("ok"))
     if manage:
-        kb.button(text="❌ Отклонить", callback_data=f"adm:m:rej:{detail.id}")
+        kb.button(text="❌ Отклонить", callback_data=_action_callback("rej"))
     if manage:
         if detail.is_active and not detail.is_deleted:
-            kb.button(text="🚫 Заблокировать", callback_data=f"adm:m:blk:{detail.id}")
+            kb.button(text="🚫 Заблокировать", callback_data=_action_callback("blk"))
         else:
-            kb.button(text="✅ Разблокировать", callback_data=f"adm:m:unb:{detail.id}")
-        kb.button(text="🎯 Изм. лимит", callback_data=f"adm:m:lim:{detail.id}")
-    kb.button(text="📄 Документы", callback_data=f"adm:m:docs:{detail.id}")
+            kb.button(text="✅ Разблокировать", callback_data=_action_callback("unb"))
+        kb.button(text="🎯 Изм. лимит", callback_data=_action_callback("lim"))
+    kb.button(text="📄 Документы", callback_data=_action_callback("docs"))
     if manage:
         delete_text = (
             "🗑 Удалить"
             if not (detail.has_orders or detail.has_commissions)
             else "🧹 Мягкое удаление"
         )
-        kb.button(text=delete_text, callback_data=f"adm:m:del:{detail.id}")
+        kb.button(text=delete_text, callback_data=_action_callback("del"))
 
-    kb.button(text="⬅️ К списку", callback_data=f"adm:m:grp:ok")
-    kb.adjust(2, 2, 1)
-
-    if mode == "moderation":
-        kb = InlineKeyboardBuilder()
-        if manage and not detail.verified:
-            kb.button(text="✅ Одобрить", callback_data=f"adm:mod:ok:{detail.id}")
-        if manage:
-            kb.button(text="❌ Отклонить", callback_data=f"adm:mod:rej:{detail.id}")
-        kb.button(text="📄 Документы", callback_data=f"adm:mod:docs:{detail.id}")
-        kb.button(text="⬅️ К списку", callback_data="adm:mod:list:1")
-        kb.adjust(1)
-        return kb.as_markup()
-
+    kb.adjust(2, 2, 2)
+    kb.row(
+        InlineKeyboardButton(
+            text="⬅️ Назад",
+            callback_data=f"{prefix}:list:{group_value}:{category_value}:{page_value}",
+        ),
+        InlineKeyboardButton(text="🏠 Меню", callback_data="adm:menu"),
+    )
     return kb.as_markup()
 
 
@@ -285,6 +354,10 @@ async def render_master_card(
     *,
     staff: StaffUser,
     mode: str = "masters",
+    prefix: str = "adm:m",
+    group: str | None = None,
+    category: str | None = None,
+    page: int | None = None,
 ) -> tuple[str, InlineKeyboardMarkup]:
     service = _masters_service(bot)
     detail = await service.get_master_detail(master_id)
@@ -338,7 +411,15 @@ async def render_master_card(
     lines.append(f"📅 Создан: {detail.created_at_local}")
     lines.append(f"🆙 Обновлён: {detail.updated_at_local}")
 
-    markup = build_card_kb(detail, staff, mode=mode)
+    markup = build_card_kb(
+        detail,
+        staff,
+        mode=mode,
+        prefix=prefix,
+        group=group,
+        category=category,
+        page=page,
+    )
     return "\n".join(lines), markup
 
 
@@ -350,6 +431,10 @@ async def _refresh_card_message(
     staff: StaffUser,
     *,
     mode: str = "masters",
+    prefix: str = "adm:m",
+    group: str | None = None,
+    category: str | None = None,
+    page: int | None = None,
 ) -> None:
     try:
         text, markup = await render_master_card(
@@ -357,6 +442,10 @@ async def _refresh_card_message(
             master_id,
             staff=staff,
             mode=mode,
+            prefix=prefix,
+            group=group,
+            category=category,
+            page=page,
         )
         await bot.edit_message_text(
             text,
@@ -368,13 +457,28 @@ async def _refresh_card_message(
         logger.debug("Failed to refresh master card", exc_info=True)
 
 
-async def refresh_card(cq: CallbackQuery, master_id: int, staff: StaffUser) -> None:
+async def refresh_card(
+    cq: CallbackQuery,
+    master_id: int,
+    staff: StaffUser,
+    *,
+    mode: str | None = None,
+    prefix: str = "adm:m",
+    group: str | None = None,
+    category: str | None = None,
+    page: int | None = None,
+) -> None:
     if not cq.message:
         return
     text, markup = await render_master_card(
         cq.bot,
         master_id,
         staff=staff,
+        mode=mode or ("moderation" if prefix == "adm:mod" else "masters"),
+        prefix=prefix,
+        group=group,
+        category=category,
+        page=page,
     )
     await cq.message.edit_text(text, reply_markup=markup)
 
@@ -435,11 +539,20 @@ async def list_page(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def master_card(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
-    text, markup = await render_master_card(cq.bot, master_id, staff=staff)
+    text, markup = await render_master_card(
+        cq.bot,
+        action.master_id,
+        staff=staff,
+        mode=action.mode,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+    )
     if cq.message:
         await cq.message.edit_text(text, reply_markup=markup)
     await cq.answer()
@@ -451,10 +564,11 @@ async def master_card(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def approve_master(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
     service = _masters_service(cq.bot)
     if not await service.approve_master(master_id, staff.id):
         await cq.answer("Не удалось обновить статус", show_alert=True)
@@ -464,7 +578,16 @@ async def approve_master(cq: CallbackQuery, staff: StaffUser) -> None:
         master_id,
         "Анкета одобрена. Вам доступна смена.",
     )
-    await refresh_card(cq, master_id, staff)
+    await refresh_card(
+        cq,
+        master_id,
+        staff,
+        mode=action.mode,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+    )
     await cq.answer("Мастер одобрен")
 
 
@@ -474,16 +597,21 @@ async def approve_master(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def ask_reject_reason(cq: CallbackQuery, state: FSMContext, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
     await state.set_state(RejectReasonState.waiting)
     await state.update_data(
-        master_id=master_id,
+        master_id=action.master_id,
         action="reject",
         origin_chat_id=cq.message.chat.id if cq.message else None,
         origin_message_id=cq.message.message_id if cq.message else None,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+        mode=action.mode,
     )
     if cq.message:
         await cq.message.answer("Укажите причину отклонения (1–200 символов).")
@@ -496,16 +624,21 @@ async def ask_reject_reason(cq: CallbackQuery, state: FSMContext, staff: StaffUs
 )
 async def ask_block_reason(cq: CallbackQuery, state: FSMContext, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
     await state.set_state(RejectReasonState.waiting)
     await state.update_data(
-        master_id=master_id,
+        master_id=action.master_id,
         action="block",
         origin_chat_id=cq.message.chat.id if cq.message else None,
         origin_message_id=cq.message.message_id if cq.message else None,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+        mode=action.mode,
     )
     if cq.message:
         await cq.message.answer("Укажите причину блокировки (1–200 символов).")
@@ -558,6 +691,11 @@ async def process_reason(message: Message, state: FSMContext, staff: StaffUser) 
             origin_message_id,
             master_id,
             staff,
+            mode=data.get("mode", "masters"),
+            prefix=str(data.get("prefix") or "adm:m"),
+            group=data.get("group"),
+            category=data.get("category"),
+            page=data.get("page"),
         )
     await state.clear()
 
@@ -568,16 +706,26 @@ async def process_reason(message: Message, state: FSMContext, staff: StaffUser) 
 )
 async def unblock_master(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
     service = _masters_service(cq.bot)
     if not await service.unblock_master(master_id, by_staff_id=staff.id):
         await cq.answer("Не удалось разблокировать", show_alert=True)
         return
     await notify_master(cq.bot, master_id, "Ваш аккаунт разблокирован.")
-    await refresh_card(cq, master_id, staff)
+    await refresh_card(
+        cq,
+        master_id,
+        staff,
+        mode=action.mode,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+    )
     await cq.answer("Разблокирован")
 
 
@@ -587,15 +735,20 @@ async def unblock_master(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def ask_limit(cq: CallbackQuery, state: FSMContext, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
     await state.set_state(ChangeLimitState.waiting)
     await state.update_data(
-        master_id=master_id,
+        master_id=action.master_id,
         origin_chat_id=cq.message.chat.id if cq.message else None,
         origin_message_id=cq.message.message_id if cq.message else None,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+        mode=action.mode,
     )
     if cq.message:
         await cq.message.answer("Введите лимит активных заказов (1–20):")
@@ -634,6 +787,11 @@ async def change_limit(message: Message, state: FSMContext, staff: StaffUser) ->
             origin_message_id,
             master_id,
             staff,
+            mode=data.get("mode", "masters"),
+            prefix=str(data.get("prefix") or "adm:m"),
+            group=data.get("group"),
+            category=data.get("category"),
+            page=data.get("page"),
         )
     await state.clear()
 
@@ -675,10 +833,11 @@ async def _relay_document(current_bot, *, chat_id: int, file_id: str, file_type:
 
 async def show_documents(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
     try:
         await cq.answer()
     except Exception:
@@ -713,16 +872,24 @@ async def show_documents(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def delete_master(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
+    group_value = action.group or ("mod" if action.mode == "moderation" else "ok")
+    category_value = action.category or "all"
+    page_value = action.page or 1
+    prefix = action.prefix
     kb = InlineKeyboardBuilder()
     kb.button(
         text="✅ Подтвердить",
-        callback_data=f"adm:m:delconfirm:{master_id}",
+        callback_data=f"{prefix}:delconfirm:{group_value}:{category_value}:{page_value}:{master_id}",
     )
-    kb.button(text="⬅️ Назад", callback_data=f"adm:m:card:{master_id}")
+    kb.button(
+        text="⬅️ Назад",
+        callback_data=f"{prefix}:card:{group_value}:{category_value}:{page_value}:{master_id}",
+    )
     if cq.message:
         await cq.message.edit_text(
             "Точно удалить мастера?", reply_markup=kb.as_markup()
@@ -736,10 +903,11 @@ async def delete_master(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def perform_delete(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
     service = _masters_service(cq.bot)
     success, soft = await service.delete_master(master_id, by_staff_id=staff.id)
     if not success:
@@ -747,7 +915,16 @@ async def perform_delete(cq: CallbackQuery, staff: StaffUser) -> None:
         return
     if soft:
         await cq.answer("Профиль помечен как удалён", show_alert=True)
-        await refresh_card(cq, master_id, staff)
+        await refresh_card(
+            cq,
+            master_id,
+            staff,
+            mode=action.mode,
+            prefix=action.prefix,
+            group=action.group,
+            category=action.category,
+            page=action.page,
+        )
     else:
         if cq.message:
             await cq.message.edit_text("Профиль удалён окончательно.", reply_markup=back_to_menu())
@@ -761,6 +938,7 @@ __all__ = [
     "build_card_kb",
     "refresh_card",
     "notify_master",
+    "parse_master_action",
     "RejectReasonState",
 ]
 

--- a/field_service/bots/admin_bot/routers/admin_moderation.py
+++ b/field_service/bots/admin_bot/routers/admin_moderation.py
@@ -70,15 +70,19 @@ async def moderation_list(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def moderation_card(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = admin_masters.parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
     text, markup = await admin_masters.render_master_card(
         cq.bot,
-        master_id,
+        action.master_id,
         staff=staff,
-        mode="moderation",
+        mode=action.mode,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
     )
     if cq.message:
         await cq.message.edit_text(text, reply_markup=markup)
@@ -91,10 +95,11 @@ async def moderation_card(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def moderation_approve(cq: CallbackQuery, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = admin_masters.parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
+    master_id = action.master_id
     service = _masters_service(cq.bot)
     by_id = staff.id
     if by_id == 0:
@@ -114,7 +119,16 @@ async def moderation_approve(cq: CallbackQuery, staff: StaffUser) -> None:
         master_id,
         "Анкета одобрена. Вам доступна смена.",
     )
-    await admin_masters.refresh_card(cq, master_id, staff)
+    await admin_masters.refresh_card(
+        cq,
+        master_id,
+        staff,
+        mode=action.mode,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+    )
     await cq.answer("Одобрено")
 
 
@@ -124,16 +138,21 @@ async def moderation_approve(cq: CallbackQuery, staff: StaffUser) -> None:
 )
 async def moderation_reject(cq: CallbackQuery, state: FSMContext, staff: StaffUser) -> None:
     try:
-        master_id = int(cq.data.split(":")[-1])
+        action = admin_masters.parse_master_action(cq.data)
     except ValueError:
         await cq.answer("Некорректный идентификатор", show_alert=True)
         return
     await state.set_state(admin_masters.RejectReasonState.waiting)
     await state.update_data(
-        master_id=master_id,
+        master_id=action.master_id,
         action="reject",
         origin_chat_id=cq.message.chat.id if cq.message else None,
         origin_message_id=cq.message.message_id if cq.message else None,
+        prefix=action.prefix,
+        group=action.group,
+        category=action.category,
+        page=action.page,
+        mode=action.mode,
     )
     if cq.message:
         await cq.message.answer("Укажите причину отклонения (1–200 символов).")

--- a/field_service/bots/common/telegram_safe.py
+++ b/field_service/bots/common/telegram_safe.py
@@ -40,6 +40,45 @@ class _SendQueue:
 _SEND_QUEUES: dict[int, _SendQueue] = {}
 
 
+def _normalize_markup(markup: InlineKeyboardMarkup | None) -> Any:
+    if markup is None:
+        return None
+    for attr in ("model_dump", "to_python", "dict"):
+        method = getattr(markup, attr, None)
+        if callable(method):
+            try:
+                return method(exclude_none=True) if attr != "to_python" else method()
+            except TypeError:
+                try:
+                    return method()
+                except TypeError:
+                    continue
+    inline_keyboard = getattr(markup, "inline_keyboard", None)
+    if inline_keyboard is None:
+        return repr(markup)
+    normalized: list[list[Any]] = []
+    for row in inline_keyboard:
+        row_payload: list[Any] = []
+        for button in row:
+            payload: Any = button
+            for attr in ("model_dump", "to_python", "dict"):
+                method = getattr(button, attr, None)
+                if callable(method):
+                    try:
+                        payload = (
+                            method(exclude_none=True) if attr != "to_python" else method()
+                        )
+                    except TypeError:
+                        try:
+                            payload = method()
+                        except TypeError:
+                            continue
+                    break
+            row_payload.append(payload)
+        normalized.append(row_payload)
+    return normalized
+
+
 def _queue_for(bot: Bot) -> _SendQueue:
     key = id(bot)
     queue = _SEND_QUEUES.get(key)
@@ -73,7 +112,29 @@ async def safe_edit_or_send(
             except TelegramBadRequest as exc:
                 message_text = (exc.message or "").lower()
                 if "message is not modified" in message_text:
-                    return message
+                    if reply_markup is not None:
+                        current_markup = _normalize_markup(message.reply_markup)
+                        new_markup = _normalize_markup(reply_markup)
+                        if current_markup != new_markup:
+                            _LOGGER.debug("safe_edit_or_send: updating reply markup only")
+                            try:
+                                await _queue_call(
+                                    message.bot,
+                                    lambda: message.edit_reply_markup(
+                                        reply_markup=reply_markup
+                                    ),
+                                )
+                            except TelegramBadRequest as markup_exc:
+                                _LOGGER.debug(
+                                    "safe_edit_or_send markup edit failed: %s",
+                                    markup_exc,
+                                    exc_info=True,
+                                )
+                            else:
+                                return message
+                    _LOGGER.debug(
+                        "safe_edit_or_send: text unchanged, sending new message"
+                    )
                 if "message to edit not found" not in message_text and "message can't be edited" not in message_text:
                     _LOGGER.debug("safe_edit_or_send edit failed: %s", exc, exc_info=True)
                 target_chat = message.chat.id

--- a/field_service/bots/master_bot/handlers/orders.py
+++ b/field_service/bots/master_bot/handlers/orders.py
@@ -30,8 +30,8 @@ from ..texts import (
     CLOSE_DOCUMENT_RECEIVED,
     CLOSE_PAYMENT_TEMPLATE,
     CLOSE_SUCCESS_TEMPLATE,
-    BACK_TO_MENU,
-    BACK_TO_OFFERS,
+    NAV_BACK,
+    NAV_MENU,
     OFFERS_EMPTY,
     OFFERS_HEADER_TEMPLATE,
     OFFERS_REFRESH_BUTTON,
@@ -59,6 +59,17 @@ from ..utils import escape_html, inline_keyboard, normalize_money, now_utc
 router = Router(name="master_orders")
 _log = logging.getLogger("master_bot.orders")
 
+
+def _callback_uid(callback: CallbackQuery) -> int | None:
+    return getattr(getattr(callback, "from_user", None), "id", None)
+
+
+def _nav_row(back_callback: str, menu_callback: str = "m:menu") -> list[InlineKeyboardButton]:
+    return [
+        InlineKeyboardButton(text=NAV_BACK, callback_data=back_callback),
+        InlineKeyboardButton(text=NAV_MENU, callback_data=menu_callback),
+    ]
+
 OFFERS_PAGE_SIZE = 5
 ACTIVE_STATUSES: tuple[m.OrderStatus, ...] = (
     m.OrderStatus.ASSIGNED,
@@ -83,7 +94,7 @@ async def offers_root(
     session: AsyncSession,
     master: m.masters,
 ) -> None:
-    _log.info("offers_root: uid=%s", getattr(getattr(callback, 'from_user', None), 'id', None))
+    _log.info("offers_root: uid=%s order_id=%s", _callback_uid(callback), None)
     await _render_offers(callback, session, master, page=1)
     await safe_answer_callback(callback)
 
@@ -108,6 +119,7 @@ async def offers_card(
     parts = callback.data.split(":")
     order_id = int(parts[2])
     page = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else 1
+    _log.info("offers_card: uid=%s order_id=%s", _callback_uid(callback), order_id)
     await _render_offer_card(callback, session, master, order_id, page)
     await safe_answer_callback(callback)
 
@@ -238,7 +250,7 @@ async def active_order_entry(
     session: AsyncSession,
     master: m.masters,
 ) -> None:
-    _log.info("active_order_entry: uid=%s", getattr(getattr(callback, 'from_user', None), 'id', None))
+    _log.info("active_order_entry: uid=%s order_id=%s", _callback_uid(callback), None)
     await _render_active_order(callback, session, master, order_id=None)
     await safe_answer_callback(callback)
 
@@ -250,6 +262,7 @@ async def active_order_card(
     master: m.masters,
 ) -> None:
     order_id = int(callback.data.split(":")[-1])
+    _log.info("active_order_card: uid=%s order_id=%s", _callback_uid(callback), order_id)
     await _render_active_order(callback, session, master, order_id=order_id)
     await safe_answer_callback(callback)
 
@@ -261,6 +274,7 @@ async def active_set_enroute(
     master: m.masters,
 ) -> None:
     order_id = int(callback.data.split(":")[-1])
+    _log.info("active_set_enroute: uid=%s order_id=%s", _callback_uid(callback), order_id)
     changed = await _update_order_status(
         session,
         master.id,
@@ -283,6 +297,7 @@ async def active_set_working(
     master: m.masters,
 ) -> None:
     order_id = int(callback.data.split(":")[-1])
+    _log.info("active_set_working: uid=%s order_id=%s", _callback_uid(callback), order_id)
     changed = await _update_order_status(
         session,
         master.id,
@@ -306,6 +321,7 @@ async def active_close_start(
     master: m.masters,
 ) -> None:
     order_id = int(callback.data.split(":")[-1])
+    _log.info("active_close_start: uid=%s order_id=%s", _callback_uid(callback), order_id)
     order = await session.get(m.orders, order_id)
     if order is None or order.assigned_master_id != master.id:
         await safe_answer_callback(callback, ALERT_ORDER_NOT_FOUND, show_alert=True)
@@ -430,7 +446,10 @@ async def _render_offers(
     offers = await _load_offers(session, master.id)
     if not offers:
         keyboard = inline_keyboard(
-            [[InlineKeyboardButton(text=OFFERS_REFRESH_BUTTON, callback_data="m:new")]]
+            [
+                [InlineKeyboardButton(text=OFFERS_REFRESH_BUTTON, callback_data="m:new")],
+                _nav_row("m:menu"),
+            ]
         )
         await safe_edit_or_send(event, OFFERS_EMPTY, keyboard)
         return
@@ -481,6 +500,8 @@ async def _render_offers(
         if nav_row:
             keyboard_rows.append(nav_row)
 
+    keyboard_rows.append(_nav_row("m:menu"))
+
     keyboard = inline_keyboard(keyboard_rows)
     text = "\n".join(lines)
     try:
@@ -504,9 +525,9 @@ async def _render_offer_card(
         await safe_edit_or_send(
             event,
             OFFER_NOT_FOUND,
-            inline_keyboard(
-                [[InlineKeyboardButton(text=BACK_TO_OFFERS, callback_data="m:new")]]
-            ),
+            inline_keyboard([
+                _nav_row("m:new")
+            ]),
         )
         return
 
@@ -544,7 +565,7 @@ async def _render_offer_card(
                     callback_data=f"m:new:dec:{order.id}:{page}",
                 ),
             ],
-            [InlineKeyboardButton(text=BACK_TO_OFFERS, callback_data="m:new")],
+            _nav_row(f"m:new:{page}" if page > 1 else "m:new"),
         ]
     )
     await safe_edit_or_send(event, card_text, keyboard)
@@ -561,9 +582,9 @@ async def _render_active_order(
         await safe_edit_or_send(
             event,
             NO_ACTIVE_ORDERS,
-            inline_keyboard(
-                [[InlineKeyboardButton(text=BACK_TO_MENU, callback_data="m:menu")]]
-            ),
+            inline_keyboard([
+                _nav_row("m:menu")
+            ]),
         )
         return
 
@@ -604,7 +625,7 @@ async def _render_active_order(
             [InlineKeyboardButton(text=title, callback_data=f"{prefix}:{order.id}")]
         )
 
-    keyboard_rows.append([InlineKeyboardButton(text=BACK_TO_MENU, callback_data="m:menu")])
+    keyboard_rows.append(_nav_row("m:act"))
     keyboard = inline_keyboard(keyboard_rows)
     text = "\n".join(text_lines)
     try:

--- a/field_service/bots/master_bot/handlers/start.py
+++ b/field_service/bots/master_bot/handlers/start.py
@@ -5,6 +5,7 @@ from aiogram.filters import Command, CommandStart
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, Message
 
+from field_service.bots.common import safe_answer_callback, safe_edit_or_send
 from field_service.db import models as m
 
 from ..keyboards import main_menu_keyboard, start_onboarding_keyboard
@@ -36,7 +37,7 @@ async def handle_menu(callback: CallbackQuery, state: FSMContext, master: m.mast
     await state.clear()
     if callback.message:
         await _render_start(callback.message, master)
-    await callback.answer()
+    await safe_answer_callback(callback)
 
 
 async def _render_start(message: Message, master: m.masters) -> None:
@@ -65,7 +66,7 @@ async def _render_start(message: Message, master: m.masters) -> None:
         "",
         escape_html(text),
     ]
-    await message.answer("\n".join(lines), reply_markup=keyboard)
+    await safe_edit_or_send(message, "\n".join(lines), keyboard)
 
 
 

--- a/field_service/bots/master_bot/texts.py
+++ b/field_service/bots/master_bot/texts.py
@@ -42,7 +42,7 @@ MAIN_MENU_BUTTONS = {
     "shift_break": "☕ Перерыв 2 часа",
     "shift_break_end": "🟢 Включить смену",
     "shift_off": "🔴 Выключить смену",
-    "new_orders": "🆕 Новые заявки",
+    "new_orders": "🆕 Новые заказы",
     "active_order": "📦 Активный заказ",
     "finance": "💳 Финансы",
     "referral": "🎁 Реферальная программа",
@@ -76,7 +76,7 @@ SHIFT_MESSAGES = {
 
 OFFERS_EMPTY = "Нет новых предложений"
 OFFERS_REFRESH_BUTTON = "🔄 Обновить"
-OFFERS_HEADER_TEMPLATE = "<b>🆕 Новые заявки</b>\nСтраница {page}/{pages} • всего: {total}"
+OFFERS_HEADER_TEMPLATE = "<b>🆕 Новые заказы</b>\nСтраница {page}/{pages} • всего: {total}"
 
 
 def _escape(value: str | None) -> str:
@@ -170,8 +170,8 @@ CLOSE_DOCUMENT_RECEIVED = "Документ получен. Проверим и 
 CLOSE_DOCUMENT_ERROR = "Нужен один файл: фото или PDF. Попробуйте ещё раз."
 
 OFFER_NOT_FOUND = "Заявка не найдена. Возможно, её уже приняли другим мастером."
-BACK_TO_OFFERS = "⬅️ К списку"
-BACK_TO_MENU = "⬅️ В главное меню"
+NAV_BACK = "⬅️ Назад"
+NAV_MENU = "🏠 Меню"
 NO_ACTIVE_ORDERS = "Сейчас нет активных заказов."
 
 ALERT_ACCOUNT_BLOCKED = "Ваш аккаунт заблокирован. Обратитесь в поддержку."


### PR DESCRIPTION
## Summary
- update safe_edit_or_send to refresh inline keyboards when text is unchanged and fall back to sending a new message
- standardize master bot UI navigation, reuse safe helpers in start handlers, add logging, and align "Новые заказы" naming
- rework admin master/moderation callback payloads and keyboards to preserve context when navigating back to filtered lists

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68dbd9a5f7208324b73c439fa3f6ccd5