### PR TITLE
Исправлена ошибка доступа к атрибуту timezone города

### DIFF
--- a/field-service/field_service/bots/admin_bot/handlers/orders/create.py
+++ b/field-service/field_service/bots/admin_bot/handlers/orders/create.py
@@ -66,21 +66,21 @@ async def is_working_hours(city_id: int, orders_service) -> bool:
     """Проверка рабочих часов с учетом timezone города и настроек из БД."""
     if os.getenv("PYTEST_CURRENT_TEST"):
         return True
-    
-    # Получаем город и его timezone
-    city = await orders_service.get_city(city_id)
-    if not city or not city.tz:
+
+    # Получаем timezone города
+    city_tz = await orders_service.get_city_timezone(city_id)
+    if not city_tz:
         return False
-    
+
     # Получаем локальное время города
     from datetime import datetime
-    tz = ZoneInfo(city.tz)
+    tz = ZoneInfo(city_tz)
     now_local = datetime.now(tz)
     current_time = now_local.time()
-    
+
     # Получаем настройки рабочего времени
     workday_start, workday_end = await _resolve_workday_window()
-    
+
     return workday_start <= current_time <= workday_end
 
 SLOT_BUCKETS: tuple[tuple[str, time, time], ...] = tuple(


### PR DESCRIPTION
Заменено использование get_city() на get_city_timezone() в функции is_working_hours. Объект CityRef не содержит поле timezone, поэтому обращение к city.tz вызывало AttributeError. Теперь используется специальный метод get_city_timezone(), который возвращает строку с timezone.

Fixes: AttributeError: 'CityRef' object has no attribute 'tz'

🤖 Generated with [Claude Code](https://claude.com/claude-code)