### PR TITLE
Исправлена ошибка использования .get() на объекте NewOrderData

### DIFF
--- a/field-service/field_service/bots/admin_bot/handlers/orders/create.py
+++ b/field-service/field_service/bots/admin_bot/handlers/orders/create.py
@@ -1078,10 +1078,10 @@ async def cb_new_order_confirm(cq: CallbackQuery, state: FSMContext, staff: Staf
     logger.info(
         f"Admin created order #{order_id}. "
         f"Staff: {staff.id} ({staff.role}), "
-        f"City: {new_order.get('city_id')}, "
-        f"District: {new_order.get('district_id')}, "
-        f"Category: {new_order.get('category')}, "
-        f"Type: {new_order.get('order_type')}"
+        f"City: {new_order.city_id}, "
+        f"District: {new_order.district_id}, "
+        f"Category: {new_order.category}, "
+        f"Type: {new_order.order_type}"
     )
     
     detail = await orders_service.get_card(order_id, city_ids=visible_city_ids_for(staff))
@@ -1134,10 +1134,10 @@ async def cb_new_order_force_confirm(cq: CallbackQuery, state: FSMContext, staff
     logger.info(
         f"Admin created DEFERRED order #{order_id} (outside working hours). "
         f"Staff: {staff.id} ({staff.role}), "
-        f"City: {new_order.get('city_id')}, "
-        f"District: {new_order.get('district_id')}, "
-        f"Category: {new_order.get('category')}, "
-        f"Type: {new_order.get('order_type')}"
+        f"City: {new_order.city_id}, "
+        f"District: {new_order.district_id}, "
+        f"Category: {new_order.category}, "
+        f"Type: {new_order.order_type}"
     )
     
     detail = await orders_service.get_card(order_id, city_ids=visible_city_ids_for(staff))


### PR DESCRIPTION
Проблема: объект NewOrderData использовался как словарь с методом .get(), но это dataclass, требующий прямого доступа к атрибутам.

Изменения:
- new_order.get('city_id') → new_order.city_id
- new_order.get('district_id') → new_order.district_id
- new_order.get('category') → new_order.category
- new_order.get('order_type') → new_order.order_type

Исправлено в двух местах:
- field_service/bots/admin_bot/handlers/orders/create.py:1081-1084
- field_service/bots/admin_bot/handlers/orders/create.py:1137-1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)