### PR TITLE
Исправлена критическая ошибка валидации клавиатур в истории заказов м…

### DIFF
--- a/field-service/field_service/bots/master_bot/handlers/history.py
+++ b/field-service/field_service/bots/master_bot/handlers/history.py
@@ -146,8 +146,8 @@ async def history_card(
 
         _log.info("history_card: creating keyboard")
         keyboard = inline_keyboard([
-            InlineKeyboardButton(text="Назад к истории", callback_data=back_callback),
-            InlineKeyboardButton(text="Главное меню", callback_data="m:menu")
+            [InlineKeyboardButton(text="Назад к истории", callback_data=back_callback)],
+            [InlineKeyboardButton(text="Главное меню", callback_data="m:menu")]
         ])
 
         _log.info("history_card: sending message")
@@ -193,7 +193,7 @@ async def _render_history(
     if total == 0:
         text = HISTORY_EMPTY
         keyboard = inline_keyboard([
-            InlineKeyboardButton(text="Главное меню", callback_data="m:menu")
+            [InlineKeyboardButton(text="Главное меню", callback_data="m:menu")]
         ])
         await safe_edit_or_send(callback, text, keyboard)
         return


### PR DESCRIPTION
…астер-бота

Проблема:
- При открытии карточки заказа из истории возникала ошибка валидации Pydantic
- Функция inline_keyboard() ожидает список списков кнопок, но получала просто список кнопок
- Это приводило к ошибке "Input should be a valid dictionary or instance of InlineKeyboardButton"

Решение:
- Исправлено создание клавиатуры в функции history_card (строки 148-151)
- Исправлено создание клавиатуры для пустой истории (строки 195-197)
- Каждая кнопка теперь обернута в отдельный список для формирования строк клавиатуры

Файлы:
- field_service/bots/master_bot/handlers/history.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)